### PR TITLE
feat: add INCOMPLETE workflow status for interrupted pipelines

### DIFF
--- a/snakesee/cli.py
+++ b/snakesee/cli.py
@@ -140,6 +140,7 @@ def status(
         WorkflowStatus.RUNNING: "green",
         WorkflowStatus.COMPLETED: "blue",
         WorkflowStatus.FAILED: "red",
+        WorkflowStatus.INCOMPLETE: "yellow",
         WorkflowStatus.UNKNOWN: "yellow",
     }
     status_color = status_colors.get(progress.status, "white")
@@ -158,6 +159,20 @@ def status(
     # Running jobs
     if progress.running_jobs:
         console.print(f"Running: {len(progress.running_jobs)} jobs")
+
+    # Incomplete jobs (jobs that were in progress when workflow was interrupted)
+    if progress.incomplete_jobs_list:
+        count = len(progress.incomplete_jobs_list)
+        console.print(f"[yellow]Incomplete: {count} job(s) were in progress[/yellow]")
+        for job in progress.incomplete_jobs_list[:5]:  # Show up to 5
+            if job.output_file:
+                try:
+                    rel_path = job.output_file.relative_to(workflow_dir)
+                    console.print(f"  [dim]- {rel_path}[/dim]")
+                except ValueError:
+                    console.print(f"  [dim]- {job.output_file}[/dim]")
+        if len(progress.incomplete_jobs_list) > 5:
+            console.print(f"  [dim]... and {len(progress.incomplete_jobs_list) - 5} more[/dim]")
 
     # Time estimation
     if not no_estimate:

--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -20,6 +20,7 @@ class WorkflowStatus(Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    INCOMPLETE = "incomplete"
     UNKNOWN = "unknown"
 
 
@@ -585,6 +586,7 @@ class WorkflowProgress:
         completed_jobs: Number of jobs completed.
         failed_jobs: Number of jobs that failed.
         failed_jobs_list: List of failed job details (for --keep-going).
+        incomplete_jobs_list: List of jobs that were in progress when workflow was interrupted.
         running_jobs: List of currently running jobs.
         recent_completions: List of recently completed jobs.
         start_time: Unix timestamp when workflow started.
@@ -597,6 +599,7 @@ class WorkflowProgress:
     completed_jobs: int
     failed_jobs: int = 0
     failed_jobs_list: list[JobInfo] = field(default_factory=list)
+    incomplete_jobs_list: list[JobInfo] = field(default_factory=list)
     running_jobs: list[JobInfo] = field(default_factory=list)
     recent_completions: list[JobInfo] = field(default_factory=list)
     start_time: float | None = None


### PR DESCRIPTION
## Summary

- Adds a new `INCOMPLETE` workflow status to distinguish workflows that were interrupted (killed/crashed) from those that failed due to job errors
- Detects incomplete state when workflow has stale locks and incomplete marker files in `.snakemake/incomplete/`
- Decodes base64 marker filenames to show output files that were in progress when the workflow was interrupted
- Displays incomplete jobs in TUI with yellow styling, replacing the "Currently Running" panel

## Changes

- **models.py**: Add `INCOMPLETE` status to `WorkflowStatus` enum, add `incomplete_jobs_list` field to `WorkflowProgress`
- **parser.py**: 
  - Update `parse_incomplete_jobs()` to decode base64 filenames and populate `output_file`
  - Update `parse_workflow_state()` to detect INCOMPLETE status and clear orphaned "running" jobs
- **tui.py**: Add incomplete jobs panel, replace running panel when status is INCOMPLETE
- **cli.py**: Update status command to display incomplete jobs

## Test plan

- [x] All 256 tests pass
- [x] Linting passes
- [x] Manual testing with interrupted workflow shows INCOMPLETE status
- [x] Manual testing shows incomplete files panel instead of running jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)