### PR TITLE
feat(tui): improve INCOMPLETE workflow display with yellow progress bar

### DIFF
--- a/snakesee/parser.py
+++ b/snakesee/parser.py
@@ -994,11 +994,10 @@ def parse_workflow_state(
     elif status != WorkflowStatus.RUNNING and incomplete_list:
         # Workflow is not running but has incomplete markers = interrupted
         status = WorkflowStatus.INCOMPLETE
-    elif status == WorkflowStatus.COMPLETED and completed < total and not running:
-        # Fallback: if workflow stopped but not all jobs completed, assume failure
-        # Only apply if there are no running jobs (avoids false positives)
-        status = WorkflowStatus.FAILED
-        failed_jobs = total - completed
+    elif status == WorkflowStatus.COMPLETED and completed < total and not workflow_is_running:
+        # Fallback: if workflow stopped but not all jobs completed, it was interrupted
+        # Only apply if workflow is not actually running (based on lock files)
+        status = WorkflowStatus.INCOMPLETE
 
     # If workflow is not actually running, clear "running" jobs from log parsing
     # (those are orphaned jobs, not truly running - they're reflected in incomplete_list)

--- a/snakesee/tui.py
+++ b/snakesee/tui.py
@@ -946,7 +946,10 @@ class WorkflowMonitorTUI:
         bar = Text()
         bar.append("█" * succeeded_width, style="green")
         bar.append("█" * failed_width, style="red")
-        bar.append("░" * remaining_width, style="dim")
+        if progress.status == WorkflowStatus.INCOMPLETE:
+            bar.append("░" * remaining_width, style="yellow")  # Incomplete = yellow
+        else:
+            bar.append("░" * remaining_width, style="dim")
 
         return bar
 
@@ -1286,7 +1289,10 @@ class WorkflowMonitorTUI:
         summary.append(" running", style="dim")
         summary.append("  │  ", style="dim")
         summary.append(f"{pending}", style="yellow" if pending > 0 else "dim")
-        summary.append(" pending", style="dim")
+        if progress.status == WorkflowStatus.INCOMPLETE:
+            summary.append(" incomplete", style="dim")
+        else:
+            summary.append(" pending", style="dim")
 
         border_style = "red" if failed > 0 else FG_BLUE
         return Panel(summary, border_style=border_style, padding=(0, 1))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -484,15 +484,15 @@ class TestParseWorkflowState:
         assert state.total_jobs == 10
         assert state.completed_jobs == 10
 
-    def test_failed_workflow(self, snakemake_dir: Path, tmp_path: Path) -> None:
-        """Test detecting a failed workflow."""
-        # No lock files, but progress incomplete
+    def test_incomplete_workflow(self, snakemake_dir: Path, tmp_path: Path) -> None:
+        """Test detecting an incomplete (interrupted) workflow."""
+        # No lock files, but progress incomplete - workflow was interrupted
         log_file = snakemake_dir / "log" / "2024-01-01T120000.snakemake.log"
         log_file.write_text("5 of 10 steps (50%) done")
 
         state = parse_workflow_state(tmp_path)
-        assert state.status == WorkflowStatus.FAILED
-        assert state.failed_jobs == 5
+        assert state.status == WorkflowStatus.INCOMPLETE
+        assert state.failed_jobs == 0  # No explicit failures, just interrupted
 
 
 class TestCollectWildcardTimingStats:


### PR DESCRIPTION
## Summary

- Fix INCOMPLETE status detection to use lock file check instead of log-parsed running jobs list
- Show remaining jobs in yellow on progress bar for INCOMPLETE workflows
- Change footer label from "pending" to "incomplete" for INCOMPLETE workflows

## Changes

- **parser.py**: Use `workflow_is_running` (lock file check) instead of `not running` (log-parsed list) for INCOMPLETE detection fallback. The `running` list isn't cleared until after status determination, causing false negatives.
- **tui.py**: 
  - Progress bar shows yellow (`░`) for remaining jobs when status is INCOMPLETE
  - Footer shows "incomplete" instead of "pending" when status is INCOMPLETE
- **tests/test_parser.py**: Update test to expect INCOMPLETE status (not FAILED) for interrupted workflows

## Test plan

- [x] All 256 tests pass
- [x] Linting passes
- [x] Manual testing with interrupted workflow shows INCOMPLETE status, yellow progress bar, and "incomplete" in footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "INCOMPLETE" status for workflow state classification.

* **Bug Fixes**
  * Enhanced workflow state detection for interrupted workflows with partial progress.
  * Progress bar styling updated to highlight incomplete workflows in yellow.
  * Status summary labels updated to display "incomplete" for partially completed workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->