### PR TITLE
fix(models): subtract incomplete jobs from pending count

### DIFF
--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -701,10 +701,14 @@ class WorkflowProgress:
 
     @property
     def pending_jobs(self) -> int:
-        """Number of jobs not yet started (excludes failed and running)."""
+        """Number of jobs not yet started (excludes failed, running, and incomplete)."""
         return max(
             0,
-            self.total_jobs - self.completed_jobs - self.failed_jobs - len(self.running_jobs),
+            self.total_jobs
+            - self.completed_jobs
+            - self.failed_jobs
+            - len(self.running_jobs)
+            - len(self.incomplete_jobs_list),
         )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -484,6 +484,20 @@ class TestWorkflowProgress:
         )
         assert progress.pending_jobs == 70  # 100 - 25 - 5
 
+    def test_pending_jobs_with_incomplete(self) -> None:
+        """Test pending jobs calculation excludes incomplete jobs."""
+        progress = WorkflowProgress(
+            workflow_dir=Path("."),
+            status=WorkflowStatus.INCOMPLETE,
+            total_jobs=100,
+            completed_jobs=25,
+            failed_jobs=2,
+            running_jobs=[],
+            incomplete_jobs_list=[JobInfo(rule="incomplete")] * 3,
+        )
+        # 100 - 25 - 2 - 0 - 3 = 70
+        assert progress.pending_jobs == 70
+
     def test_elapsed_seconds(self) -> None:
         """Test elapsed seconds calculation."""
         start = time.time() - 60


### PR DESCRIPTION
## Summary

- Fixes incorrect job count in footer summary when workflow has incomplete jobs
- The `pending_jobs` calculation now subtracts `incomplete_jobs_list` in addition to completed, failed, and running jobs
- Adds test coverage for the incomplete jobs scenario

**Before:** Footer showed 5991 total when `total_jobs` was 5990 (off by 1 incomplete job)
**After:** Footer correctly sums to match `total_jobs`

## Test plan

- [x] Existing `test_pending_jobs` still passes
- [x] New `test_pending_jobs_with_incomplete` validates the fix
- [x] Full test suite passes (289 tests)
- [x] Coverage threshold met (65.56%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the pending jobs calculation to properly exclude incomplete jobs from the remaining count.

* **Tests**
  * Added new test validating pending jobs calculation excludes incomplete items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->