### PR TITLE
build: add mypy to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,11 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: uv run poe check-typing
+        language: system
+        types: [python]
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- Add local mypy hook to pre-commit configuration
- Uses `uv run poe check-typing` to leverage existing mypy config from pyproject.toml
- Catches type errors before commit, preventing CI failures like PR #8

## Test plan
- [x] `uv run pre-commit run --all-files` passes
- [x] Hook runs in ~0.35s, minimal impact on commit workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)