### PR TITLE
fix: filter pending jobs and stats by current workflow rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.14.9
     hooks:
       - id: ruff
         args: [--fix]

--- a/snakesee/tui.py
+++ b/snakesee/tui.py
@@ -1563,7 +1563,9 @@ class WorkflowMonitorTUI:
                 if rule not in completed_by_rule:
                     completed_by_rule[rule] = stats.count
 
-        return self._estimator._infer_pending_rules(completed_by_rule, progress.pending_jobs)
+        return self._estimator._infer_pending_rules(
+            completed_by_rule, progress.pending_jobs, self._estimator.current_rules
+        )
 
     def _read_log_tail(self, log_path: Path, max_lines: int = 500) -> list[str]:
         """
@@ -1897,8 +1899,15 @@ class WorkflowMonitorTUI:
         from snakesee.parser import parse_metadata_files
 
         if self._cutoff_time is None:
-            # Latest log: use all stats from estimator
+            # Latest log: use stats from estimator, filtered by current workflow rules
             if self._estimator and self._estimator.rule_stats:
+                current_rules = self._estimator.current_rules
+                if current_rules is not None:
+                    return [
+                        stats
+                        for stats in self._estimator.rule_stats.values()
+                        if stats.rule in current_rules
+                    ]
                 return list(self._estimator.rule_stats.values())
             return []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,6 +144,7 @@ def mock_estimator() -> MagicMock:
     estimator.estimate_remaining.return_value = make_time_estimate()
     estimator.get_rule_estimate.return_value = (100.0, 0.8)
     estimator._infer_pending_rules.return_value = {"align": 5, "sort": 3}
+    estimator.current_rules = None  # No filtering by default
     return estimator
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "snakesee"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "defopt" },


### PR DESCRIPTION
## Summary
- Fix pending jobs showing rule names from previous workflows run in the same directory
- Fix historical statistics showing rules that don't exist in the current workflow
- Both issues caused by metadata from `.snakemake/metadata/` containing all historical rules

## Root Cause
When running different Snakemake workflows in the same directory:
1. `_get_inferred_pending_rules()` wasn't filtering by `current_rules`, causing rules from previous workflows to appear in pending job estimates
2. `_get_filtered_stats()` returned all historical rule stats without filtering by current workflow rules

## Changes
- Pass `current_rules` to `_infer_pending_rules()` in `_get_inferred_pending_rules()`
- Filter rule stats by `current_rules` in `_get_filtered_stats()` when viewing the latest log
- Update test fixture to explicitly set `current_rules = None` for correct mock behavior

## Test plan
- [x] All existing tests pass (335 tests)
- [ ] Manual testing: run workflow A, then workflow B in same directory - verify only workflow B rules appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pending-rule time estimates now respect the estimator's active rule set for more accurate predictions.
  * Statistics view filters to show only currently tracked rules, while preserving prior behavior when no active set is present.

* **Tests**
  * Integration tests relaxed exact job-count assertions to tolerate CI timing variability.
  * Test fixtures default the estimator's active-rule set to none to preserve prior behavior.

* **Chores**
  * Updated formatter hook/version in pre-commit configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->