### PR TITLE
fix: use incomplete markers to detect running workflows

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -231,9 +231,11 @@ class TestIsWorkflowRunning:
         incomplete_marker = incomplete_dir / "c29tZV9vdXRwdXRfZmlsZQ=="  # base64 encoded
         incomplete_marker.write_text("")
 
-        # Incomplete markers do NOT indicate the workflow is running - they persist
-        # after a workflow is killed. Log freshness is the primary indicator.
-        assert is_workflow_running(snakemake_dir) is False
+        # When locks AND incomplete markers both exist, the workflow is running.
+        # Incomplete markers are created when jobs START and removed when they FINISH,
+        # so their presence combined with locks strongly indicates active execution.
+        # (Log freshness is only used as a fallback when no incomplete markers exist)
+        assert is_workflow_running(snakemake_dir) is True
 
 
 class TestCollectRuleTimingStats:

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "snakesee"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "defopt" },


### PR DESCRIPTION
## Summary
- Fix false "INCOMPLETE" status for long-running cluster jobs
- When both lock files AND incomplete markers exist, consider the workflow as running regardless of log file freshness
- Log freshness check (30 minute threshold) is now only used as a fallback when no incomplete markers exist

## Problem
For cluster workflows where jobs run for hours, the Snakemake log may not be updated frequently. The previous logic required the log to be modified within 30 minutes, causing active workflows to incorrectly show as "INCOMPLETE".

## Solution
Incomplete markers in `.snakemake/incomplete/` are created when jobs START and removed when they FINISH. If both locks AND incomplete markers exist, the workflow is definitely running - this is now the primary detection method.

## Test plan
- [x] Updated test to reflect new behavior
- [x] All 335 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of running workflows by checking for active job indicators before using log analysis as a fallback method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->