### PR TITLE
fix: make test_keep_going_mixed more robust

### DIFF
--- a/tests/integration/test_workflows.py
+++ b/tests/integration/test_workflows.py
@@ -509,7 +509,9 @@ class TestKeepGoing:
     def test_keep_going_mixed(self, workflow_runner: WorkflowRunner) -> None:
         """Test --keep-going with mixed success/failure branches."""
         workflow_runner.setup_workflow("keep_going_mixed")
-        run_result = workflow_runner.run(expect_failure=True, cores=4, extra_args=["--keep-going"])
+        # Use cores=1 for deterministic execution order - this test validates
+        # --keep-going behavior, not parallel failure handling
+        run_result = workflow_runner.run(expect_failure=True, cores=1, extra_args=["--keep-going"])
 
         # Should fail overall
         assert run_result.returncode != 0

--- a/tests/integration/workflows/keep_going_mixed/Snakefile
+++ b/tests/integration/workflows/keep_going_mixed/Snakefile
@@ -30,6 +30,7 @@ rule branch_a_fails:
     output: "output/a_complete.txt"
     shell:
         """
+        sleep 0.3
         echo "Branch A failing"
         exit 1
         """
@@ -39,6 +40,7 @@ rule branch_c_fails:
     output: "output/c_complete.txt"
     shell:
         """
+        sleep 0.3
         echo "Branch C failing"
         exit 1
         """


### PR DESCRIPTION
## Summary
- Use `cores=1` for deterministic execution order
- Add small delays (0.3s) to failing jobs

## Problem
The `test_keep_going_mixed` integration test was flaky - it expected 2 failures but sometimes only captured 1. This was a race condition where jobs failing very quickly could race with Snakemake's event tracking.

## Solution
1. **Sequential execution (`cores=1`)**: The test validates `--keep-going` behavior (continuing after failures), not parallel failure handling. Sequential execution makes the test deterministic.

2. **Small delays in failing jobs**: A 0.3s delay ensures Snakemake fully registers each job before it fails. Without this, a job might fail before the event system tracks it.

Note: The log handler script already has proper flushing (`f.flush()` + `os.fsync()`), so no changes needed there.

## Test plan
- [x] `test_keep_going_mixed` passes locally
- [x] All 49 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved deterministic execution of workflow tests by adjusting test configuration parameters.
  * Added timing adjustments to test failure paths for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->