### PR TITLE
fix: refresh current_rules when new workflow starts

### DIFF
--- a/snakesee/tui.py
+++ b/snakesee/tui.py
@@ -168,6 +168,7 @@ class WorkflowMonitorTUI:
         # Log file navigation
         self._available_logs: list[Path] = []
         self._current_log_index: int = 0  # 0 = most recent
+        self._latest_log_path: Path | None = None  # Track latest log to detect new workflows
         self._refresh_log_list()
 
         # Table sorting state
@@ -234,6 +235,13 @@ class WorkflowMonitorTUI:
         # Reset to most recent if current index is out of bounds
         if self._current_log_index >= len(self._available_logs):
             self._current_log_index = 0
+
+        # Detect when a new workflow starts (new latest log)
+        # and re-parse current_rules to filter pending jobs correctly
+        new_latest = self._available_logs[0] if self._available_logs else None
+        if new_latest != self._latest_log_path:
+            self._latest_log_path = new_latest
+            self._init_current_rules_from_log()
 
     def _get_current_log(self) -> Path | None:
         """Get the currently selected log file."""


### PR DESCRIPTION
## Summary

- Fixes bug where "Pending Jobs" showed rules from previous workflows when watching a new workflow
- When a new log file is detected (indicating a new workflow started), re-parse `current_rules` from the new log
- This ensures only rules from the current workflow appear in the pending jobs panel

## Test plan

- [x] Run `snakesee watch` on a workflow directory
- [x] Start a new Snakemake workflow with different rules
- [x] Verify "Pending Jobs" only shows rules from the new workflow
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of pending jobs filtering when switching between different workflow logs by enhancing how workflow changes are detected and processed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->