### PR TITLE
fix: improve arrow key handling and job selection bounds

### DIFF
--- a/snakesee/tui.py
+++ b/snakesee/tui.py
@@ -2270,6 +2270,8 @@ class WorkflowMonitorTUI:
             return
 
         try:
+            import fcntl
+            import os
             import select
             import termios
             import tty
@@ -2298,20 +2300,15 @@ class WorkflowMonitorTUI:
             ) as live:
                 last_update = time.time()
 
-                import fcntl
-                import os as os_module
-
-                fd = sys.stdin.fileno()
-
                 while self._running:
                     # Check for keyboard input (non-blocking)
                     if sys.stdin in select.select([sys.stdin], [], [], 0.1)[0]:
                         # Read all available input at once using os.read
                         # to avoid buffering issues with escape sequences
                         old_flags = fcntl.fcntl(fd, fcntl.F_GETFL)
-                        fcntl.fcntl(fd, fcntl.F_SETFL, old_flags | os_module.O_NONBLOCK)
+                        fcntl.fcntl(fd, fcntl.F_SETFL, old_flags | os.O_NONBLOCK)
                         try:
-                            data = os_module.read(fd, 32)
+                            data = os.read(fd, 32)
                             chars = data.decode("utf-8", errors="ignore")
                         except BlockingIOError:
                             chars = ""


### PR DESCRIPTION
## Summary

- Rewrote escape sequence parsing to use `os.read()` consistently, fixing buffering issues that caused arrow keys to trigger historical log navigation instead of job selection
- Added support for both CSI (`ESC [`) and SS3 (`ESC O`) arrow key sequences
- Added bounds clamping for selected job indices in both running and completions tables
- Prevents selection from "deselecting" when pressing arrow key at the end of a list

## Test plan

- [x] Run `snakesee watch` on a workflow with running jobs
- [x] Press Enter to enter job selection mode
- [x] Verify arrow keys navigate between jobs
- [x] Verify pressing down arrow at the last job keeps it selected (doesn't deselect)
- [x] Verify pressing up arrow at the first job keeps it selected
- [x] Tab to completions and verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented out-of-bounds navigation when moving selection in job and completion lists.

* **Improvements**
  * Switched to non-blocking, buffered input handling for snappier keyboard response.
  * More reliable arrow-key detection and mapping for smoother navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->