### PR TITLE
chore: update setup-uv from v4 to v7

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,11 +27,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "${{ env.UV_VERSION }}"
           python-version: "${{ matrix.PYTHON_VERSION }}"
-          enable-cache: 'true'
+          enable-cache: true
           cache-suffix: "integration-${{ matrix.PYTHON_VERSION }}-${{ matrix.SNAKEMAKE_VERSION }}"
 
       - name: Install dependencies with specific Snakemake version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,11 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "${{ env.UV_VERSION }}"
           python-version: "3.12"
+          enable-cache: true
 
       - name: Build package
         run: uv build --sdist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,11 +26,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "${{ env.UV_VERSION }}"
           python-version: "${{ matrix.PYTHON_VERSION }}"
-          enable-cache: 'true'
+          enable-cache: true
           cache-suffix: "${{ matrix.PYTHON_VERSION }}"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Update `astral-sh/setup-uv` action from v4 to v7 to fix caching issues.

Addresses frequent cache save failures seen in CI logs:
```
Warning: Failed to save: <h2>Our services aren't available right now</h2>
```

## Key improvements in v7

- Adds OS version to cache key (prevents binary incompatibility)
- Better cache conflict handling
- Improved cache pruning

## Changes

- Updated all workflow files to use `setup-uv@v7`
- Changed `enable-cache: 'true'` (string) to `enable-cache: true` (boolean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use the latest version of the uv setup action across integration tests, tests, and publishing pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->