### PR TITLE
feat: add Codecov and Read the Docs badges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
           uv run poe build-docs
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: nh13/snakesee

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![License][license-badge]][license-link]
 
 [![Tests][tests-badge]][tests-link]
+[![codecov][codecov-badge]][codecov-link]
+[![Documentation][docs-badge]][docs-link]
 [![PyPI version][pypi-badge]][pypi-link]
 [![PyPI downloads][pypi-downloads-badge]][pypi-link]
 [![Bioconda][bioconda-badge]][bioconda-link]
@@ -399,6 +401,10 @@ This codebase was written with the assistance of AI (Claude). All code has been 
 [license-link]: https://github.com/nh13/snakesee/blob/main/LICENSE
 [tests-badge]: https://github.com/nh13/snakesee/actions/workflows/tests.yml/badge.svg
 [tests-link]: https://github.com/nh13/snakesee/actions/workflows/tests.yml
+[codecov-badge]: https://codecov.io/gh/nh13/snakesee/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/nh13/snakesee
+[docs-badge]: https://readthedocs.org/projects/snakesee/badge/?version=latest
+[docs-link]: https://snakesee.readthedocs.io/en/latest/
 [pypi-badge]: https://img.shields.io/pypi/v/snakesee
 [pypi-link]: https://pypi.org/project/snakesee/
 [pypi-downloads-badge]: https://img.shields.io/pypi/dm/snakesee


### PR DESCRIPTION
## Summary
- Add Codecov badge showing test coverage percentage
- Add Read the Docs badge linking to documentation

Replaces #27 (closed due to force push after rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded code coverage integration

* **Documentation**
  * Added codecov and documentation badges to project README

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->