### PR TITLE
fix: detect and ignore stale events files from previous workflow runs

### DIFF
--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -689,7 +689,7 @@ class WorkflowProgress:
         """
         if self.total_jobs == 0:
             return 0.0
-        return (self.completed_jobs / self.total_jobs) * 100
+        return min(100.0, (self.completed_jobs / self.total_jobs) * 100)
 
     @property
     def elapsed_seconds(self) -> float | None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -487,6 +487,16 @@ class TestWorkflowProgress:
         )
         assert progress.percent_complete == 0.0
 
+    def test_percent_complete_capped_at_100(self) -> None:
+        """Test percent complete is capped at 100 when completed exceeds total."""
+        progress = WorkflowProgress(
+            workflow_dir=Path("."),
+            status=WorkflowStatus.RUNNING,
+            total_jobs=1718,
+            completed_jobs=1864,  # More completed than total (can happen with parsing issues)
+        )
+        assert progress.percent_complete == 100.0
+
     def test_pending_jobs(self) -> None:
         """Test pending jobs calculation."""
         progress = WorkflowProgress(

--- a/uv.lock
+++ b/uv.lock
@@ -1742,7 +1742,7 @@ wheels = [
 
 [[package]]
 name = "snakesee"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "defopt" },


### PR DESCRIPTION
## Summary

- Fix incorrect progress display (105%) when watching a workflow that doesn't use the snakesee logger plugin
- The TUI was reading events from a stale `.snakesee_events.jsonl` file left over from a previous run
- Added validation to check if the events file's `workflow_started` timestamp matches the current log file's start time
- Cap `WorkflowProgress.percent_complete` at 100% as a safeguard

## Test plan

- [x] Added tests for `_is_event_file_current()` validation function
- [x] Added test for capped percentage at 100%
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress percentage is now capped at 100% to prevent overflow when actual progress exceeds expectations.
  * Event file validation ensures only data from the current workflow run is processed, preventing stale data from being loaded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->