### PR TITLE
fix: populate job registry from log parsing when events unavailable

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1742,7 +1742,7 @@ wheels = [
 
 [[package]]
 name = "snakesee"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "defopt" },


### PR DESCRIPTION
## Summary

- Fixed bug where the Pending Jobs panel showed incorrect counts when the snakesee logger plugin wasn't used
- The job registry was only being populated from events, leaving it nearly empty when using log parsing alone
- Now syncs completed jobs from log reader to registry, making the registry the single source of truth

## Problem

When running `snakesee watch` without the logger plugin, completed jobs (e.g., `compare_metrics`) were incorrectly shown as "pending" because:
1. The job registry was only populated from events (not available without the plugin)
2. Code was using `recent_completions` (limited to 10 jobs) instead of all completed jobs
3. The pending jobs calculation used incomplete data

## Solution

1. Sync log reader's completed jobs to registry when events aren't available
2. Use registry as single source of truth for all completed job counts
3. Update `_get_inferred_pending_rules()` to use registry instead of `recent_completions`
4. Update `_update_rule_stats_from_completions()` to iterate registry completed jobs
5. Update `_compute_pending_jobs_from_scheduled()` calls to use registry

## Test plan

- [x] Ran `snakesee watch` on a workflow without the logger plugin
- [x] Verified Pending Jobs panel shows accurate counts
- [x] All 176 TUI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of job completion tracking by consolidating data sources for more consistent status reporting.
  * Enhanced robustness when event data is unavailable, with better synchronization of completed job information across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->