### PR TITLE
fix: defer error event emission until error block fully parsed

### DIFF
--- a/snakesee/parser/line_parser.py
+++ b/snakesee/parser/line_parser.py
@@ -57,6 +57,14 @@ class ParsingContext:
     timestamp: float | None = None
     log_path: str | None = None
 
+    # Pending error state - we defer ERROR emission until the error block is fully parsed
+    # because jobid and log come AFTER "Error in rule X:" in the error block
+    pending_error_rule: str | None = None
+    error_jobid: str | None = None
+    error_wildcards: dict[str, str] | None = None
+    error_threads: int | None = None
+    error_log_path: str | None = None
+
     def reset_for_new_rule(self, rule: str) -> None:
         """Reset context when entering a new rule block.
 
@@ -69,6 +77,61 @@ class ParsingContext:
         self.threads = None
         self.log_path = None
 
+    def start_error_block(self, rule: str) -> None:
+        """Start tracking a pending error block.
+
+        Args:
+            rule: Name of the rule that errored.
+        """
+        self.pending_error_rule = rule
+        # Initialize with current context if rule matches
+        if self.rule == rule:
+            self.error_jobid = self.jobid
+            self.error_wildcards = self.wildcards
+            self.error_threads = self.threads
+            self.error_log_path = self.log_path
+        else:
+            self.error_jobid = None
+            self.error_wildcards = None
+            self.error_threads = None
+            self.error_log_path = None
+
+    def get_pending_error(self) -> ParseEvent | None:
+        """Get the pending error event and clear it.
+
+        Returns:
+            ParseEvent for the error, or None if no pending error.
+        """
+        if self.pending_error_rule is None:
+            return None
+
+        # Strip "(check log file(s) for error details)" suffix from error blocks
+        log_path = self.error_log_path
+        if log_path and " (check log file" in log_path:
+            log_path = log_path.split(" (check log file")[0].strip()
+
+        event = ParseEvent(
+            ParseEventType.ERROR,
+            {
+                "rule": self.pending_error_rule,
+                "jobid": self.error_jobid,
+                "wildcards": self.error_wildcards,
+                "threads": self.error_threads,
+                "log_path": log_path,
+            },
+        )
+        # Clear pending error state
+        self.pending_error_rule = None
+        self.error_jobid = None
+        self.error_wildcards = None
+        self.error_threads = None
+        self.error_log_path = None
+        return event
+
+    def has_pending_error(self) -> bool:
+        """Check if there's a pending error to emit."""
+        return self.pending_error_rule is not None
+
 
 @dataclass
 class LogLineParser:
@@ -80,101 +143,112 @@ class LogLineParser:
 
     context: ParsingContext = field(default_factory=ParsingContext)
 
-    def parse_line(self, line: str) -> ParseEvent | None:
-        """Parse a single log line and return structured event.
+    def parse_line(self, line: str) -> list[ParseEvent]:
+        """Parse a single log line and return structured events.
 
         Uses fast-path prefix checks to skip expensive regex operations
         for lines that can't possibly match.
 
         Updates internal context as needed for multi-line entries.
+        May return multiple events when a pending error needs to be flushed.
 
         Args:
             line: Log line to parse.
 
         Returns:
-            ParseEvent if the line contains relevant information, None otherwise.
+            List of ParseEvents (may be empty, one, or two events).
         """
         line = line.rstrip("\n\r")
+        events: list[ParseEvent] = []
 
         # Fast path: empty lines
         if not line:
-            return None
+            return events
 
         first_char = line[0]
 
-        # Timestamp lines start with '['
+        # Timestamp lines start with '[' - this ends error blocks
         if first_char == "[":
             if match := TIMESTAMP_PATTERN.match(line):
+                # Flush any pending error before emitting timestamp
+                if pending := self.context.get_pending_error():
+                    events.append(pending)
                 timestamp = _parse_timestamp(match.group(1))
                 self.context.timestamp = timestamp
-                return ParseEvent(ParseEventType.TIMESTAMP, {"timestamp": timestamp})
-            return None
+                events.append(ParseEvent(ParseEventType.TIMESTAMP, {"timestamp": timestamp}))
+            return events
 
         # Indented lines (properties) start with space/tab
         if first_char in (" ", "\t"):
-            return self._parse_indented_line(line)
+            event = self._parse_indented_line(line)
+            if event:
+                events.append(event)
+            return events
 
-        # Rule start: "rule X:" or "localrule X:"
+        # Rule start: "rule X:" or "localrule X:" - this ends error blocks
         if first_char == "r" and line.startswith("rule "):
             if match := RULE_START_PATTERN.match(line):
+                # Flush any pending error before emitting rule start
+                if pending := self.context.get_pending_error():
+                    events.append(pending)
                 rule = match.group(1)
                 self.context.reset_for_new_rule(rule)
-                return ParseEvent(ParseEventType.RULE_START, {"rule": rule})
-            return None
+                events.append(ParseEvent(ParseEventType.RULE_START, {"rule": rule}))
+            return events
 
         if first_char == "l" and line.startswith("localrule "):
             if match := RULE_START_PATTERN.match(line):
+                # Flush any pending error before emitting rule start
+                if pending := self.context.get_pending_error():
+                    events.append(pending)
                 rule = match.group(1)
                 self.context.reset_for_new_rule(rule)
-                return ParseEvent(ParseEventType.RULE_START, {"rule": rule})
-            return None
+                events.append(ParseEvent(ParseEventType.RULE_START, {"rule": rule}))
+            return events
 
         # Finished job: "Finished job X" or "Finished jobid: X"
         if first_char == "F" and line.startswith("Finished "):
             if match := FINISHED_JOB_PATTERN.search(line):
                 jobid = match.group(1)
-                return ParseEvent(
-                    ParseEventType.JOB_FINISHED,
-                    {"jobid": jobid, "timestamp": self.context.timestamp},
+                events.append(
+                    ParseEvent(
+                        ParseEventType.JOB_FINISHED,
+                        {"jobid": jobid, "timestamp": self.context.timestamp},
+                    )
                 )
-            return None
+            return events
 
-        # Error detection: "Error in rule X:"
+        # Error detection: "Error in rule X:" - starts a pending error block
         if first_char == "E" and line.startswith("Error in rule "):
             if match := ERROR_IN_RULE_PATTERN.search(line):
+                # Flush any previous pending error before starting new one
+                if pending := self.context.get_pending_error():
+                    events.append(pending)
                 rule = match.group(1)
-                # Use context if error rule matches current context
-                if self.context.rule == rule:
-                    return ParseEvent(
-                        ParseEventType.ERROR,
-                        {
-                            "rule": rule,
-                            "jobid": self.context.jobid,
-                            "wildcards": self.context.wildcards,
-                            "threads": self.context.threads,
-                            "log_path": self.context.log_path,
-                        },
-                    )
-                return ParseEvent(
-                    ParseEventType.ERROR,
-                    {
-                        "rule": rule,
-                        "jobid": None,
-                        "wildcards": None,
-                        "threads": None,
-                        "log_path": None,
-                    },
-                )
-            return None
+                # Start pending error - we'll capture jobid/log from subsequent lines
+                self.context.start_error_block(rule)
+            return events
 
         # Progress line: "X of Y steps (Z%) done" - check with substring first
         if "steps" in line and "done" in line:
             if match := PROGRESS_PATTERN.search(line):
                 completed = int(match.group(1))
                 total = int(match.group(2))
-                return ParseEvent(ParseEventType.PROGRESS, {"completed": completed, "total": total})
+                events.append(
+                    ParseEvent(ParseEventType.PROGRESS, {"completed": completed, "total": total})
+                )
 
-        return None
+        return events
+
+    def flush_pending_error(self) -> ParseEvent | None:
+        """Flush any pending error event.
+
+        Call this at end of file or when needing to ensure all errors are emitted.
+
+        Returns:
+            ParseEvent for the pending error, or None if no pending error.
+        """
+        return self.context.get_pending_error()
 
     def _parse_indented_line(self, line: str) -> ParseEvent | None:
         """Parse indented property lines (wildcards, threads, log, jobid).
@@ -192,6 +266,9 @@ class LogLineParser:
             value = stripped[10:].strip()  # len('wildcards:') = 10
             wildcards = _parse_wildcards(value)
             self.context.wildcards = wildcards
+            # Also update error context if in error block
+            if self.context.has_pending_error():
+                self.context.error_wildcards = wildcards
             return ParseEvent(
                 ParseEventType.WILDCARDS,
                 {"wildcards": wildcards, "jobid": self.context.jobid},
@@ -202,6 +279,9 @@ class LogLineParser:
             threads = _parse_positive_int(value, "threads")
             if threads is not None:
                 self.context.threads = threads
+                # Also update error context if in error block
+                if self.context.has_pending_error():
+                    self.context.error_threads = threads
                 return ParseEvent(
                     ParseEventType.THREADS,
                     {"threads": threads, "jobid": self.context.jobid},
@@ -211,6 +291,9 @@ class LogLineParser:
         if stripped.startswith("log:"):
             log_path = stripped[4:].strip()  # len('log:') = 4
             self.context.log_path = log_path
+            # Also update error context if in error block
+            if self.context.has_pending_error():
+                self.context.error_log_path = log_path
             return ParseEvent(
                 ParseEventType.LOG_PATH,
                 {"log_path": log_path, "jobid": self.context.jobid},
@@ -219,6 +302,9 @@ class LogLineParser:
         if stripped.startswith("jobid:"):
             jobid = stripped[6:].strip()  # len('jobid:') = 6
             self.context.jobid = jobid
+            # Also update error context if in error block
+            if self.context.has_pending_error():
+                self.context.error_jobid = jobid
             return ParseEvent(
                 ParseEventType.JOBID,
                 {

--- a/snakesee/tui/monitor.py
+++ b/snakesee/tui/monitor.py
@@ -858,6 +858,10 @@ class WorkflowMonitorTUI:
                 new_failed_list.append(job)
         new_failed = len(new_failed_list)
 
+        # Filter running jobs to exclude failed jobs (a job can't be both running and failed)
+        failed_job_ids = {job.job_id for job in new_failed_list if job.job_id}
+        new_running_jobs = [job for job in new_running_jobs if job.job_id not in failed_job_ids]
+
         # Apply stored threads/wildcards to running jobs that may have lost them
         # (log-parsed jobs may not have threads if the line order varies)
         for i, job in enumerate(new_running_jobs):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -296,7 +296,7 @@ class TestLineParserBenchmarks:
             parser = LogLineParser()
             count = 0
             for line in sample_log_lines:
-                if parser.parse_line(line) is not None:
+                if parser.parse_line(line):  # non-empty list
                     count += 1
             return count
 
@@ -320,7 +320,7 @@ class TestLineParserBenchmarks:
             parser = LogLineParser()
             count = 0
             for line in nonmatching_lines:
-                if parser.parse_line(line) is None:
+                if not parser.parse_line(line):  # empty list
                     count += 1
             return count
 
@@ -343,7 +343,7 @@ class TestLineParserBenchmarks:
             parser = LogLineParser()
             count = 0
             for line in indented_lines:
-                if parser.parse_line(line) is not None:
+                if parser.parse_line(line):  # non-empty list
                     count += 1
             return count
 

--- a/uv.lock
+++ b/uv.lock
@@ -1742,7 +1742,7 @@ wheels = [
 
 [[package]]
 name = "snakesee"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "defopt" },


### PR DESCRIPTION
## Summary
- Fix error blocks not capturing jobid and log file because they appear AFTER "Error in rule X:" line
- Fix failed jobs incorrectly showing as "running" by filtering running jobs against failed jobs list
- Add deferred ERROR event emission to both batch parsers (`core.py`) and incremental parser (`line_parser.py`)

## Test plan
- [x] Added tests for error block parsing with deferred jobid/log capture
- [x] Added tests for failed jobs excluded from running list
- [x] Added tests for LogLineParser deferred ERROR handling
- [x] All 971 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where failed jobs were incorrectly included in the running jobs list.
  * Improved error message formatting by removing redundant error detail suffixes from log paths.
  * Enhanced error block parsing to capture complete job metadata (ID, rule context, log path) when failures occur.

* **Tests**
  * Added comprehensive test coverage for failed job handling and error parsing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->