### PR TITLE
feat: make help shortcut more discoverable in TUI footer

### DIFF
--- a/snakesee/tui/monitor.py
+++ b/snakesee/tui/monitor.py
@@ -2793,6 +2793,8 @@ class WorkflowMonitorTUI:
 
         footer.append(f"Updated: {now}", style="dim")
         footer.append("  │  ", style="dim")
+        footer.append("? help", style="bold cyan")
+        footer.append("  │  ", style="dim")
 
         # Show log position (e.g., "Log: 1/10" or "Log: 3/10 [historical]")
         total_logs = len(self._available_logs)
@@ -2834,9 +2836,6 @@ class WorkflowMonitorTUI:
         footer.append("snakesee", style=f"bold {FG_BLUE}")
         footer.append(" by ", style="dim")
         footer.append("Fulcrum Genomics", style=FG_BLUE)
-        footer.append("  │  ")
-        footer.append("?", style="bold")
-        footer.append("=help", style="dim")
 
         return Panel(footer, border_style=FG_BLUE, padding=(0, 1))
 


### PR DESCRIPTION
## Summary
- Move the help hint ("? help") to the beginning of the footer so it's visible even on narrower terminals
- Style it with bold cyan to make it stand out from other status information

Previously the hint was at the far right end with dim styling, making it easy to miss.

## Test plan
- [ ] Run `snakesee watch` and verify the "? help" hint is visible near the start of the footer
- [ ] Verify pressing `?` still shows the help overlay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved help indicator visibility in the monitor footer with a clearer, more direct label for easier user access to help information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->