### PR TITLE
fix: remove 10-job cap on recent_completions

### DIFF
--- a/snakesee/parser/core.py
+++ b/snakesee/parser/core.py
@@ -1261,7 +1261,7 @@ def parse_workflow_state(
         failed_jobs_list=failed_list,
         incomplete_jobs_list=incomplete_list,
         running_jobs=running,
-        recent_completions=completions[:10],
+        recent_completions=completions,
         start_time=start_time,
         log_file=log_path,
     )


### PR DESCRIPTION
The hard-coded [:10] slice meant the estimator only saw 10 completed jobs, causing it to fall back to historical execution counts for unrepresented rules and drastically overestimate remaining work.

## Description

<!-- Briefly describe the changes in this PR -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other (please describe):

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation as needed

## Testing

<!-- Describe how you tested these changes -->

## Related Issues

<!-- Link to related issues if applicable -->
Closes #

## Additional Notes

<!-- Any additional information that reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow progress now displays the complete completion history instead of limiting visibility to the ten most recent completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->