### PR TITLE
feat: segmented progress bar with running/pending counts

### DIFF
--- a/snakesee/tui/accessibility.py
+++ b/snakesee/tui/accessibility.py
@@ -37,6 +37,7 @@ class AccessibilityConfig:
 
     succeeded: BarStyle
     failed: BarStyle
+    running: BarStyle
     remaining: BarStyle
     incomplete: BarStyle
     show_legend: bool
@@ -45,6 +46,7 @@ class AccessibilityConfig:
 DEFAULT_CONFIG = AccessibilityConfig(
     succeeded=BarStyle(char="\u2588", label="succeeded"),
     failed=BarStyle(char="\u2588", label="failed"),
+    running=BarStyle(char="\u2588", label="running"),
     remaining=BarStyle(char="\u2591", label="remaining"),
     incomplete=BarStyle(char="\u2591", label="incomplete"),
     show_legend=False,
@@ -53,6 +55,7 @@ DEFAULT_CONFIG = AccessibilityConfig(
 ACCESSIBLE_CONFIG = AccessibilityConfig(
     succeeded=BarStyle(char="=", label="succeeded"),
     failed=BarStyle(char="X", label="failed"),
+    running=BarStyle(char=">", label="running"),
     remaining=BarStyle(char="\u00b7", label="remaining"),
     incomplete=BarStyle(char="?", label="incomplete"),
     show_legend=True,

--- a/snakesee/tui/accessibility.py
+++ b/snakesee/tui/accessibility.py
@@ -30,6 +30,7 @@ class AccessibilityConfig:
     Attributes:
         succeeded: Style for completed/succeeded jobs.
         failed: Style for failed jobs.
+        running: Style for currently running jobs.
         remaining: Style for remaining/pending jobs.
         incomplete: Style for incomplete jobs (workflow interrupted).
         show_legend: If True, always show the legend (not just on failure).

--- a/snakesee/tui/monitor.py
+++ b/snakesee/tui/monitor.py
@@ -1702,32 +1702,25 @@ class WorkflowMonitorTUI:
         return Panel(header_text, style="white on grey23", border_style=FG_BLUE, height=3)
 
     def _make_progress_bar(self, progress: WorkflowProgress, width: int = 40) -> Text:
-        """Create a colored progress bar showing succeeded/failed portions."""
+        """Create a colored progress bar showing succeeded/failed/running/pending portions."""
         total = max(1, progress.total_jobs)
         succeeded = progress.completed_jobs
         failed = progress.failed_jobs
+        running = len(progress.running_jobs)
         config = self._accessibility_config
 
-        # Calculate widths for each segment
+        # Calculate widths for each segment, distributing rounding remainders
         succeeded_width = int((succeeded / total) * width)
         failed_width = int((failed / total) * width)
-        unfinished = max(0, progress.total_jobs - progress.completed_jobs - progress.failed_jobs)
-        incomplete = (
-            min(len(progress.incomplete_jobs_list), unfinished)
-            if progress.status == WorkflowStatus.INCOMPLETE
-            else 0
-        )
-        incomplete_width = int((incomplete / total) * width)
-        remaining_width = width - succeeded_width - failed_width - incomplete_width
+        running_width = int((running / total) * width)
+        pending_width = width - succeeded_width - failed_width - running_width
 
         # Build the bar with colored segments
         bar = Text()
         bar.append(config.succeeded.char * succeeded_width, style="green")
         bar.append(config.failed.char * failed_width, style="red")
-        if incomplete_width > 0:
-            bar.append(config.incomplete.char * incomplete_width, style="yellow")
-        if remaining_width > 0:
-            bar.append(config.remaining.char * remaining_width, style="dim")
+        bar.append(config.running.char * running_width, style="yellow")
+        bar.append(config.remaining.char * pending_width, style="dim")
 
         return bar
 
@@ -1748,6 +1741,8 @@ class WorkflowMonitorTUI:
 
         # Create colored progress bar
         progress_bar = self._make_progress_bar(progress, width=bar_width)
+
+        running = len(progress.running_jobs)
 
         # Progress text line
         progress_line = Text()
@@ -1788,35 +1783,26 @@ class WorkflowMonitorTUI:
 
         eta_text = Text.from_markup("  ".join(eta_parts)) if eta_parts else Text("")
 
-        # Legend for the progress bar
+        # Legend for the progress bar showing non-zero segments
         config = self._accessibility_config
         legend = Text()
-        show_legend = progress.failed_jobs > 0 or config.show_legend
-        if show_legend:
+        legend_parts: list[tuple[str, str, str]] = []
+        if progress.completed_jobs > 0:
+            legend_parts.append((config.succeeded.char, "green", f"{progress.completed_jobs} {config.succeeded.label}"))
+        if progress.failed_jobs > 0:
+            legend_parts.append((config.failed.char, "red", f"{progress.failed_jobs} {config.failed.label}"))
+        if running > 0:
+            legend_parts.append((config.running.char, "yellow", f"{running} {config.running.label}"))
+        pending = total - progress.completed_jobs - progress.failed_jobs - running
+        if pending > 0:
+            legend_parts.append((config.remaining.char, "dim", f"{pending} {config.remaining.label}"))
+        if legend_parts:
             legend.append("  (", style="dim")
-            legend.append(config.succeeded.char, style="green")
-            legend.append(f"={progress.completed_jobs} {config.succeeded.label}", style="dim")
-            if progress.failed_jobs > 0:
-                legend.append("  ", style="dim")
-                legend.append(config.failed.char, style="red")
-                legend.append(f"={progress.failed_jobs} {config.failed.label}", style="dim")
-            unfinished = max(
-                0, progress.total_jobs - progress.completed_jobs - progress.failed_jobs
-            )
-            incomplete = (
-                min(len(progress.incomplete_jobs_list), unfinished)
-                if progress.status == WorkflowStatus.INCOMPLETE
-                else 0
-            )
-            remaining = unfinished - incomplete
-            if incomplete > 0:
-                legend.append("  ", style="dim")
-                legend.append(config.incomplete.char, style="yellow")
-                legend.append(f"={incomplete} {config.incomplete.label}", style="dim")
-            if remaining > 0:
-                legend.append("  ", style="dim")
-                legend.append(config.remaining.char, style="dim")
-                legend.append(f"={remaining} {config.remaining.label}", style="dim")
+            for i, (symbol, style, label) in enumerate(legend_parts):
+                if i > 0:
+                    legend.append("  ", style="dim")
+                legend.append(symbol, style=style)
+                legend.append(f"={label}", style="dim")
             legend.append(")", style="dim")
 
         # Border color based on status (use FG colors for normal states)
@@ -1829,19 +1815,12 @@ class WorkflowMonitorTUI:
         }
         border_style = border_colors.get(progress.status, FG_BLUE)
 
-        # Combine progress line with legend if present
-        if show_legend:
-            full_progress = Text()
-            full_progress.append(progress_line)
-            full_progress.append(legend)
-            return Panel(
-                Group(full_progress, eta_text),
-                title="Progress",
-                border_style=border_style,
-            )
-
+        # Combine progress line with legend
+        full_progress = Text()
+        full_progress.append(progress_line)
+        full_progress.append(legend)
         return Panel(
-            Group(progress_line, eta_text),
+            Group(full_progress, eta_text),
             title="Progress",
             border_style=border_style,
         )

--- a/snakesee/tui/monitor.py
+++ b/snakesee/tui/monitor.py
@@ -56,6 +56,7 @@ from snakesee.state.workflow_state import WorkflowState
 from snakesee.tui.accessibility import ACCESSIBLE_CONFIG
 from snakesee.tui.accessibility import DEFAULT_CONFIG
 from snakesee.tui.accessibility import AccessibilityConfig
+from snakesee.tui.accessibility import BarStyle
 from snakesee.validation import EventAccumulator
 from snakesee.validation import ValidationLogger
 from snakesee.validation import compare_states
@@ -1701,25 +1702,51 @@ class WorkflowMonitorTUI:
 
         return Panel(header_text, style="white on grey23", border_style=FG_BLUE, height=3)
 
+    def _in_flight_segment(self, progress: WorkflowProgress) -> tuple[int, BarStyle]:
+        """Return the count and style for the in-flight (yellow) progress segment.
+
+        The yellow segment shows jobs that are mid-flight. Which jobs those are depends on
+        whether the workflow is live or stopped:
+
+        - A live workflow reports its currently-executing jobs via ``running_jobs``.
+        - A stopped (``INCOMPLETE``) workflow has no live jobs, so we surface the jobs that
+          were in progress when it was interrupted (``incomplete_jobs_list``). This preserves
+          the post-mortem "which jobs were interrupted" distinction when browsing a dead run.
+
+        Args:
+            progress: Current workflow progress.
+
+        Returns:
+            A tuple of (number of in-flight jobs, the BarStyle to render them with).
+        """
+        config = self._accessibility_config
+        if progress.status == WorkflowStatus.INCOMPLETE:
+            return len(progress.incomplete_jobs_list), config.incomplete
+        return len(progress.running_jobs), config.running
+
     def _make_progress_bar(self, progress: WorkflowProgress, width: int = 40) -> Text:
-        """Create a colored progress bar showing succeeded/failed/running/pending portions."""
+        """Create a colored progress bar showing succeeded/failed/in-flight/pending portions."""
         total = max(1, progress.total_jobs)
         succeeded = progress.completed_jobs
         failed = progress.failed_jobs
-        running = len(progress.running_jobs)
+        in_flight, in_flight_style = self._in_flight_segment(progress)
         config = self._accessibility_config
 
-        # Calculate widths for each segment, distributing rounding remainders
-        succeeded_width = int((succeeded / total) * width)
-        failed_width = int((failed / total) * width)
-        running_width = int((running / total) * width)
-        pending_width = width - succeeded_width - failed_width - running_width
+        # Calculate widths for each segment. Clamp each to non-negative bounds within the
+        # remaining width so a transient counter skew (counts briefly exceeding total) can
+        # never produce a negative segment and under-render the bar.
+        succeeded_width = min(width, max(0, int((succeeded / total) * width)))
+        failed_width = min(width - succeeded_width, max(0, int((failed / total) * width)))
+        in_flight_width = min(
+            width - succeeded_width - failed_width, max(0, int((in_flight / total) * width))
+        )
+        pending_width = max(0, width - succeeded_width - failed_width - in_flight_width)
 
         # Build the bar with colored segments
         bar = Text()
         bar.append(config.succeeded.char * succeeded_width, style="green")
         bar.append(config.failed.char * failed_width, style="red")
-        bar.append(config.running.char * running_width, style="yellow")
+        bar.append(in_flight_style.char * in_flight_width, style="yellow")
         bar.append(config.remaining.char * pending_width, style="dim")
 
         return bar
@@ -1741,8 +1768,6 @@ class WorkflowMonitorTUI:
 
         # Create colored progress bar
         progress_bar = self._make_progress_bar(progress, width=bar_width)
-
-        running = len(progress.running_jobs)
 
         # Progress text line
         progress_line = Text()
@@ -1788,14 +1813,27 @@ class WorkflowMonitorTUI:
         legend = Text()
         legend_parts: list[tuple[str, str, str]] = []
         if progress.completed_jobs > 0:
-            legend_parts.append((config.succeeded.char, "green", f"{progress.completed_jobs} {config.succeeded.label}"))
+            legend_parts.append(
+                (
+                    config.succeeded.char,
+                    "green",
+                    f"{progress.completed_jobs} {config.succeeded.label}",
+                )
+            )
         if progress.failed_jobs > 0:
-            legend_parts.append((config.failed.char, "red", f"{progress.failed_jobs} {config.failed.label}"))
-        if running > 0:
-            legend_parts.append((config.running.char, "yellow", f"{running} {config.running.label}"))
-        pending = total - progress.completed_jobs - progress.failed_jobs - running
+            legend_parts.append(
+                (config.failed.char, "red", f"{progress.failed_jobs} {config.failed.label}")
+            )
+        in_flight, in_flight_style = self._in_flight_segment(progress)
+        if in_flight > 0:
+            legend_parts.append(
+                (in_flight_style.char, "yellow", f"{in_flight} {in_flight_style.label}")
+            )
+        pending = progress.pending_jobs
         if pending > 0:
-            legend_parts.append((config.remaining.char, "dim", f"{pending} {config.remaining.label}"))
+            legend_parts.append(
+                (config.remaining.char, "dim", f"{pending} {config.remaining.label}")
+            )
         if legend_parts:
             legend.append("  (", style="dim")
             for i, (symbol, style, label) in enumerate(legend_parts):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2245,14 +2245,17 @@ class TestAccessibility:
         assert "succeeded" in output
         assert "remaining" in output
 
-    def test_default_mode_legend_shows_segments(
-        self, tui_with_mocks: WorkflowMonitorTUI
-    ) -> None:
+    def test_default_mode_legend_shows_segments(self, tui_with_mocks: WorkflowMonitorTUI) -> None:
         """In default mode, legend shows non-zero segments."""
         from snakesee.tui.accessibility import DEFAULT_CONFIG
 
         tui_with_mocks._accessibility_config = DEFAULT_CONFIG
-        progress = make_workflow_progress(total_jobs=100, completed_jobs=50, failed_jobs=0)
+        progress = make_workflow_progress(
+            total_jobs=100,
+            completed_jobs=50,
+            failed_jobs=0,
+            running_jobs=[make_job_info(rule="align"), make_job_info(rule="sort")],
+        )
         panel = tui_with_mocks._make_progress_panel(progress, None)
         from io import StringIO
 
@@ -2264,6 +2267,7 @@ class TestAccessibility:
         output = buf.getvalue()
         assert "succeeded" in output
         assert "failed" not in output
+        assert "running" in output
         assert "remaining" in output
 
     def test_toggle_accessible_mode_with_key(self, tui_with_mocks: WorkflowMonitorTUI) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2245,10 +2245,10 @@ class TestAccessibility:
         assert "succeeded" in output
         assert "remaining" in output
 
-    def test_default_mode_no_legend_without_failures(
+    def test_default_mode_legend_shows_segments(
         self, tui_with_mocks: WorkflowMonitorTUI
     ) -> None:
-        """In default mode, legend is not shown when there are no failures."""
+        """In default mode, legend shows non-zero segments."""
         from snakesee.tui.accessibility import DEFAULT_CONFIG
 
         tui_with_mocks._accessibility_config = DEFAULT_CONFIG
@@ -2262,7 +2262,9 @@ class TestAccessibility:
         console = Console(file=buf, width=120, force_terminal=True)
         console.print(panel)
         output = buf.getvalue()
-        assert "succeeded" not in output
+        assert "succeeded" in output
+        assert "failed" not in output
+        assert "remaining" in output
 
     def test_toggle_accessible_mode_with_key(self, tui_with_mocks: WorkflowMonitorTUI) -> None:
         """Pressing 'a' toggles between default and accessible mode."""


### PR DESCRIPTION
## Summary

- Progress bar now shows four proportional segments: green (succeeded), red (failed), yellow (running), dim (pending)
- Legend always displays non-zero segment counts, so the bar is informative even before any jobs complete
- Previously, running jobs were invisible in the progress bar — the bar was entirely yellow/dim until jobs finished

## Test plan

- [x] Existing TUI tests pass (183/183)
- [ ] Manual verification with a running pipeline to confirm yellow segments appear on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Progress bar reliably shows four segments — succeeded, failed, running, and pending — with stable width allocation and unified legend rendering.
* **Style**
  * Added a distinct visual style for the running segment and adjusted pending visuals for clearer status differentiation.
* **Tests**
  * Updated TUI accessibility test expectations to match the new legend and segment behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/snakesee/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->