### PR TITLE
feat: QoL improvements: shortcutkeys++, version made visible, completion time to include date and TZ

### DIFF
--- a/snakesee/tui/monitor.py
+++ b/snakesee/tui/monitor.py
@@ -8,6 +8,7 @@ import sys
 import time
 from collections.abc import Iterable
 from datetime import datetime
+from datetime import timedelta
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -214,6 +215,7 @@ class WorkflowMonitorTUI:
                 Defaults to DEFAULT_CONFIG (standard block characters).
         """
         self.workflow_dir = workflow_dir
+        self._resolved_workflow_dir = str(workflow_dir.resolve())
         self.refresh_rate = refresh_rate
         self.use_estimation = use_estimation
         self.profile_path = profile_path
@@ -1248,10 +1250,8 @@ class WorkflowMonitorTUI:
         Table mode: Navigate between jobs in running/completions tables.
         Press Enter to view a job's log, Esc to exit to normal mode.
         """
-        # Help key works in table mode
-        if key == "?":
-            self._show_help = True
-            self._force_refresh = True
+        # Toggle keys (?, p, e, w, a, r, Ctrl+r) work in table mode
+        if self._handle_toggle_key(key):
             return False
 
         # Sort keys work in table mode
@@ -1449,10 +1449,8 @@ class WorkflowMonitorTUI:
         Log mode: Scroll through the selected job's log file.
         Press Esc to return to table navigation mode.
         """
-        # Help key works in log mode
-        if key == "?":
-            self._show_help = True
-            self._force_refresh = True
+        # Toggle keys (?, p, e, w, a, r, Ctrl+r) work in log mode
+        if self._handle_toggle_key(key):
             return False
 
         # Escape - exit log viewing mode, return to table navigation
@@ -1635,10 +1633,12 @@ class WorkflowMonitorTUI:
         help_text.add_row("Ctrl+f/b", "Scroll down/up full page")
         help_text.add_row("Esc", "Return to table navigation")
 
+        from snakesee import __version__
+
         return Panel(
             help_text,
             title="[bold]Keyboard Shortcuts[/bold]",
-            subtitle="Press any key to close",
+            subtitle=f"Press any key to close [dim]│ snakesee v{__version__}[/dim]",
             border_style="cyan",
         )
 
@@ -1680,7 +1680,13 @@ class WorkflowMonitorTUI:
         header_text.append(" │ ", style="dim")
         header_text.append("Snakemake Monitor", style="bold white")
         header_text.append("  │  ", style="dim")
-        header_text.append(str(self.workflow_dir), style="dim")
+        # Truncate long paths to avoid crowding out status fields
+        resolved = self._resolved_workflow_dir
+        max_path_len = max(20, (self.console.width or 80) - 80)
+        if len(resolved) > max_path_len:
+            # Keep first component + ... + last components that fit
+            resolved = resolved[: max_path_len // 2 - 1] + "…" + resolved[-(max_path_len // 2) :]
+        header_text.append(resolved, style="dim")
         header_text.append("  │  Status: ")
         header_text.append(progress.status.value.upper(), style=style)
 
@@ -1774,9 +1780,14 @@ class WorkflowMonitorTUI:
             eta_parts.append(f"ETA: {estimate.format_eta()}")
 
             if estimate.seconds_remaining < float("inf") and estimate.seconds_remaining > 0:
-                completion_time = datetime.now().timestamp() + estimate.seconds_remaining
-                completion_str = datetime.fromtimestamp(completion_time).strftime("%H:%M:%S")
-                eta_parts.append(f"(completion: {completion_str})")
+                now = datetime.now().astimezone()
+                completion_dt = now + timedelta(seconds=estimate.seconds_remaining)
+                tz_name = completion_dt.strftime("%Z") or "local"
+                if completion_dt.date() == now.date():
+                    completion_str = completion_dt.strftime("%H:%M:%S")
+                else:
+                    completion_str = completion_dt.strftime("%Y-%m-%d %H:%M:%S")
+                eta_parts.append(f"({completion_str} {tz_name})")
 
             # Show estimation method and inferred cores for transparency
             method_info = estimate.method

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1639,6 +1639,95 @@ class TestJobSelectionModeKeyHandling:
         # Job index should NOT have changed (key was consumed by help close)
         assert tui._selected_job_index == 5
 
+    def test_toggle_keys_work_in_table_mode(self, tui: WorkflowMonitorTUI) -> None:
+        """Test that toggle keys (p, e, w, a, r, Ctrl+r) work in table navigation mode."""
+        tui._job_selection_mode = True
+        tui._log_source = "running"
+
+        # p toggles pause
+        assert not tui._paused
+        tui._handle_key("p")
+        assert tui._paused
+        assert tui._job_selection_mode is True  # type: ignore[unreachable]  # stays in table mode
+
+        # e toggles estimation
+        initial_est = tui.use_estimation
+        tui._handle_key("e")
+        assert tui.use_estimation != initial_est
+        assert tui._job_selection_mode is True
+
+        # w toggles wildcard conditioning
+        initial_wc = tui._use_wildcard_conditioning
+        tui._handle_key("w")
+        assert tui._use_wildcard_conditioning != initial_wc
+        assert tui._job_selection_mode is True
+
+        # a toggles accessibility
+        from snakesee.tui.accessibility import ACCESSIBLE_CONFIG
+        from snakesee.tui.accessibility import DEFAULT_CONFIG
+
+        assert tui._accessibility_config == DEFAULT_CONFIG
+        tui._handle_key("a")
+        assert tui._accessibility_config == ACCESSIBLE_CONFIG
+        assert tui._job_selection_mode is True
+
+        # r triggers force refresh without leaving table mode
+        tui._force_refresh = False
+        tui._handle_key("r")
+        assert tui._force_refresh is True
+        assert tui._job_selection_mode is True
+
+        # Ctrl+r triggers hard refresh without leaving table mode
+        tui._force_refresh = False
+        tui._handle_key("\x12")
+        assert tui._force_refresh is True
+        assert tui._job_selection_mode is True
+
+    def test_toggle_keys_work_in_log_viewing_mode(self, tui: WorkflowMonitorTUI) -> None:
+        """Test that toggle keys (p, e, w, a, r, Ctrl+r) work in log viewing mode."""
+        tui._job_selection_mode = True
+        tui._log_viewing_mode = True
+        tui._log_source = "running"
+
+        # p toggles pause
+        assert not tui._paused
+        tui._handle_key("p")
+        assert tui._paused
+        assert tui._log_viewing_mode is True  # type: ignore[unreachable]  # stays in log mode
+
+        # w toggles wildcard conditioning
+        initial_wc = tui._use_wildcard_conditioning
+        tui._handle_key("w")
+        assert tui._use_wildcard_conditioning != initial_wc
+        assert tui._log_viewing_mode is True
+
+        # e toggles estimation
+        initial_est = tui.use_estimation
+        tui._handle_key("e")
+        assert tui.use_estimation != initial_est
+        assert tui._log_viewing_mode is True
+
+        # a toggles accessibility
+        from snakesee.tui.accessibility import ACCESSIBLE_CONFIG
+        from snakesee.tui.accessibility import DEFAULT_CONFIG
+
+        assert tui._accessibility_config == DEFAULT_CONFIG
+        tui._handle_key("a")
+        assert tui._accessibility_config == ACCESSIBLE_CONFIG
+        assert tui._log_viewing_mode is True
+
+        # r triggers force refresh without leaving log mode
+        tui._force_refresh = False
+        tui._handle_key("r")
+        assert tui._force_refresh is True
+        assert tui._log_viewing_mode is True
+
+        # Ctrl+r triggers hard refresh without leaving log mode
+        tui._force_refresh = False
+        tui._handle_key("\x12")
+        assert tui._force_refresh is True
+        assert tui._log_viewing_mode is True
+
     def test_g_jumps_to_first_job_in_running(self, tui: WorkflowMonitorTUI) -> None:
         """Test that 'g' jumps to first job in running table."""
         tui._job_selection_mode = True


### PR DESCRIPTION
## Summary
- Show resolved absolute path in header (e.g., `/home/user/workflow` instead of `.`)
- Show snakesee version in help panel (`?`) subtitle
- Show date in ETA completion time when it crosses midnight, and always include timezone
- Make toggle keys (`p`, `e`, `w`, `a`, `r`, `Ctrl+r`) work in table navigation and log viewing modes

## Test plan
- [x] All 1084 tests pass
- [x] ruff format/lint clean
- [x] mypy clean
- [ ] Manual: run `snakesee watch .` and verify header shows full path
- [ ] Manual: press `?` and verify version in subtitle
- [ ] Manual: verify toggle keys work after pressing `Enter` (table mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle and refresh keys (including Ctrl+R) now work consistently inside nested table-navigation and log-viewing modes

* **Improvements**
  * Help overlay subtitle shows the installed snakesee version
  * ETA uses timezone-aware completion times with clearer date/time formatting and timezone label
  * Workflow header shows resolved absolute path and truncates to fit the terminal

* **Tests**
  * Added tests verifying toggle/refresh key behavior in selection and log-viewing modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/snakesee/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->