### PR TITLE
feat: dynamic table row counts based on terminal height

### DIFF
--- a/snakesee/tui/monitor.py
+++ b/snakesee/tui/monitor.py
@@ -273,6 +273,8 @@ class WorkflowMonitorTUI:
         self._selected_stats_index: int = 0  # Index into stats rows list
         self._pending_scroll_offset: int = 0  # Scroll offset for pending table
         self._stats_scroll_offset: int = 0  # Scroll offset for stats table
+        self._left_panel_count: int = 2  # Number of panels in left column
+        self._right_panel_count: int = 2  # Number of panels in right column
         self._log_scroll_offset: int = 0  # Lines to skip from end (0 = show latest)
         self._log_scroll_page_size: int = 10  # Lines to scroll with Ctrl+u/d
         self._cached_log_path: Path | None = None
@@ -1640,6 +1642,20 @@ class WorkflowMonitorTUI:
             border_style="cyan",
         )
 
+    def _max_visible_rows(self, num_panels: int) -> int:
+        """Compute max visible table rows based on terminal height and layout.
+
+        In FULL layout, the body area (terminal - fixed chrome) is split equally
+        among panels. Each panel loses ~3 lines for border + header row.
+        Returns at least 3 rows so tables are always usable.
+        """
+        height = self.console.height or 24
+        # Fixed chrome: header(3) + progress(6) + summary_footer(3) + footer(3) = 15
+        body_height = height - 15
+        panel_height = body_height // max(1, num_panels)
+        # Panel border (2) + table header row (1) = 3 lines of overhead
+        return max(3, panel_height - 3)
+
     def _make_header(self, progress: WorkflowProgress) -> Panel:
         """Create the header panel with workflow path and status."""
         status_styles = {
@@ -2034,7 +2050,8 @@ class WorkflowMonitorTUI:
             job_data = self._sort_running_job_data(job_data)
 
         # Virtual scrolling for running jobs table
-        max_visible = 10
+        num_panels = 1 if self._layout_mode == LayoutMode.COMPACT else self._left_panel_count
+        max_visible = self._max_visible_rows(num_panels)
         is_selecting_running = self._job_selection_mode and self._log_source == "running"
 
         if is_selecting_running and job_data:
@@ -2185,7 +2202,7 @@ class WorkflowMonitorTUI:
         header_style = "bold green on dark_blue" if is_sorting else "bold green"
 
         # Virtual scrolling for completions table
-        max_visible = 8
+        max_visible = self._max_visible_rows(self._right_panel_count)
         is_selecting = self._job_selection_mode and self._log_source == "completions"
 
         # Use heap selection when only displaying top N (not scrolling)
@@ -2588,7 +2605,7 @@ class WorkflowMonitorTUI:
             rules_list.sort(key=lambda x: x[1], reverse=True)
 
         # Virtual scrolling
-        max_visible = 10
+        max_visible = self._max_visible_rows(self._left_panel_count)
         total_rules = len(rules_list)
 
         if is_selecting and rules_list:
@@ -2832,7 +2849,7 @@ class WorkflowMonitorTUI:
                 all_rows.append((rule, "-", stats))
 
         # Virtual scrolling
-        max_visible = 8
+        max_visible = self._max_visible_rows(self._right_panel_count)
         total_rows = len(all_rows)
 
         if is_selecting and all_rows:
@@ -3004,6 +3021,10 @@ class WorkflowMonitorTUI:
             # Check if we have incomplete jobs to show
             has_failed = bool(progress.failed_jobs_list)
             has_incomplete = bool(progress.incomplete_jobs_list)
+
+            # Track panel counts for dynamic row sizing
+            self._left_panel_count = 3 if has_incomplete else 2
+            self._right_panel_count = 3 if has_failed else 2
 
             # Left column: running jobs, incomplete jobs (if any), pending jobs
             if has_incomplete:

--- a/snakesee/tui/monitor.py
+++ b/snakesee/tui/monitor.py
@@ -1645,16 +1645,24 @@ class WorkflowMonitorTUI:
     def _max_visible_rows(self, num_panels: int) -> int:
         """Compute max visible table rows based on terminal height and layout.
 
-        In FULL layout, the body area (terminal - fixed chrome) is split equally
-        among panels. Each panel loses ~3 lines for border + header row.
+        Body area (terminal - fixed chrome) is split equally among panels.
+        Each panel loses ~3 lines for border + header row.
         Returns at least 3 rows so tables are always usable.
         """
         height = self.console.height or 24
-        # Fixed chrome: header(3) + progress(6) + summary_footer(3) + footer(3) = 15
-        body_height = height - 15
+        # FULL: header(3) + progress(6) + summary_footer(3) + footer(3) = 15
+        # COMPACT/MINIMAL: header(3) + progress(6) + footer(3) = 12
+        fixed_chrome = 15 if self._layout_mode == LayoutMode.FULL else 12
+        body_height = height - fixed_chrome
         panel_height = body_height // max(1, num_panels)
         # Panel border (2) + table header row (1) = 3 lines of overhead
         return max(3, panel_height - 3)
+
+    def _update_panel_counts(self, progress: WorkflowProgress) -> None:
+        """Update panel counts based on current workflow state."""
+        if self._layout_mode == LayoutMode.FULL:
+            self._left_panel_count = 3 if progress.incomplete_jobs_list else 2
+            self._right_panel_count = 3 if progress.failed_jobs_list else 2
 
     def _make_header(self, progress: WorkflowProgress) -> Panel:
         """Create the header panel with workflow path and status."""
@@ -2956,6 +2964,7 @@ class WorkflowMonitorTUI:
         estimate: TimeEstimate | None,
     ) -> Layout:
         """Create the complete TUI layout."""
+        self._update_panel_counts(progress)
         layout = Layout()
 
         # Easter egg takes over the whole screen
@@ -3021,10 +3030,6 @@ class WorkflowMonitorTUI:
             # Check if we have incomplete jobs to show
             has_failed = bool(progress.failed_jobs_list)
             has_incomplete = bool(progress.incomplete_jobs_list)
-
-            # Track panel counts for dynamic row sizing
-            self._left_panel_count = 3 if has_incomplete else 2
-            self._right_panel_count = 3 if has_failed else 2
 
             # Left column: running jobs, incomplete jobs (if any), pending jobs
             if has_incomplete:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2421,3 +2421,13 @@ class TestMaxVisibleRows:
         # height=24, chrome=15, body=9, per panel=4, minus overhead=1 → floor 3
         result = tui._max_visible_rows(2)
         assert result == 3
+
+    def test_minimal_layout_matches_compact_chrome(self, tui: WorkflowMonitorTUI) -> None:
+        """MINIMAL layout uses the same chrome math as COMPACT."""
+        from snakesee.tui.monitor import LayoutMode
+
+        tui._layout_mode = LayoutMode.MINIMAL
+        minimal_rows = tui._max_visible_rows(2)
+        tui._layout_mode = LayoutMode.COMPACT
+        compact_rows = tui._max_visible_rows(2)
+        assert minimal_rows == compact_rows

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2347,3 +2347,77 @@ class TestAccessibility:
         # Should show both incomplete and remaining counts
         assert "5 incomplete" in output
         assert "45 remaining" in output
+
+
+class TestMaxVisibleRows:
+    """Tests for _max_visible_rows dynamic row calculation."""
+
+    @pytest.fixture
+    def tui(self, tmp_path: Path) -> WorkflowMonitorTUI:
+        """Create a TUI with a mocked console of known dimensions."""
+        snakemake_dir = tmp_path / ".snakemake"
+        snakemake_dir.mkdir()
+        (snakemake_dir / "log").mkdir()
+        mock_console = MagicMock()
+        mock_console.width = 120
+        mock_console.height = 50
+        mock_console.is_terminal = True
+        with patch("snakesee.tui.monitor.Console", return_value=mock_console):
+            return WorkflowMonitorTUI(workflow_dir=tmp_path)
+
+    def test_full_layout_two_panels(self, tui: WorkflowMonitorTUI) -> None:
+        """Standard terminal, FULL layout, 2 panels per column."""
+        from snakesee.tui.monitor import LayoutMode
+
+        tui._layout_mode = LayoutMode.FULL
+        # height=50, chrome=15, body=35, per panel=17, minus overhead=14
+        result = tui._max_visible_rows(2)
+        assert result == 14
+
+    def test_full_layout_three_panels(self, tui: WorkflowMonitorTUI) -> None:
+        """Standard terminal, FULL layout, 3 panels per column."""
+        from snakesee.tui.monitor import LayoutMode
+
+        tui._layout_mode = LayoutMode.FULL
+        # height=50, chrome=15, body=35, per panel=11, minus overhead=8
+        result = tui._max_visible_rows(3)
+        assert result == 8
+
+    def test_compact_layout_one_panel(self, tui: WorkflowMonitorTUI) -> None:
+        """COMPACT layout uses less chrome (no summary_footer), giving more rows."""
+        from snakesee.tui.monitor import LayoutMode
+
+        tui._layout_mode = LayoutMode.COMPACT
+        # height=50, chrome=12, body=38, per panel=38, minus overhead=35
+        result = tui._max_visible_rows(1)
+        assert result == 35
+
+    def test_compact_vs_full_gives_more_rows(self, tui: WorkflowMonitorTUI) -> None:
+        """COMPACT layout yields more rows than FULL for the same panel count."""
+        from snakesee.tui.monitor import LayoutMode
+
+        tui._layout_mode = LayoutMode.COMPACT
+        compact_rows = tui._max_visible_rows(2)
+        tui._layout_mode = LayoutMode.FULL
+        full_rows = tui._max_visible_rows(2)
+        assert compact_rows > full_rows
+
+    def test_small_terminal_floor(self, tui: WorkflowMonitorTUI) -> None:
+        """Very small terminal returns minimum of 3 rows."""
+        from snakesee.tui.monitor import LayoutMode
+
+        tui.console.height = 10
+        tui._layout_mode = LayoutMode.FULL
+        # height=10, chrome=15, body=-5 → floor of 3
+        result = tui._max_visible_rows(2)
+        assert result == 3
+
+    def test_none_height_uses_default(self, tui: WorkflowMonitorTUI) -> None:
+        """None console height falls back to 24."""
+        from snakesee.tui.monitor import LayoutMode
+
+        tui.console.height = None
+        tui._layout_mode = LayoutMode.FULL
+        # height=24, chrome=15, body=9, per panel=4, minus overhead=1 → floor 3
+        result = tui._max_visible_rows(2)
+        assert result == 3


### PR DESCRIPTION
## Summary
- Replace hardcoded `max_visible` values (10 for running/pending, 8 for completions/stats) with dynamic calculation based on terminal height
- Tables now fill available vertical space on tall terminals and shrink gracefully on short ones
- Accounts for layout mode (compact vs full) and number of panels per column (2 or 3, depending on whether failed/incomplete panels are shown)
- Minimum 3 rows always displayed

Closes #59

## Test plan
- [x] All 1082 tests pass
- [x] ruff format/lint clean
- [x] mypy clean
- [ ] Manual: resize terminal vertically and verify tables grow/shrink
- [ ] Manual: verify with failed/incomplete jobs (3-panel columns)
- [ ] Manual: verify compact layout gives running table more rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Tables and panels now dynamically adjust visible rows based on terminal height, layout mode, and which panels are active; COMPACT layout shows more rows than FULL. Very small or unknown terminal heights are clamped to a sensible minimum to preserve readability.
* **Tests**
  * Added tests verifying visible-row behavior across layouts, panel counts, tiny terminals, and missing console dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->