### PR TITLE
fix: show pending jobs before first completion

### DIFF
--- a/snakesee/tui/monitor.py
+++ b/snakesee/tui/monitor.py
@@ -502,10 +502,10 @@ class WorkflowMonitorTUI:
         if current_rules:
             self._estimator.current_rules = current_rules
 
-        # Parse job counts for accurate pending job inference
-        job_counts = parse_job_stats_counts_from_log(log_path)
-        if job_counts:
-            self._estimator.expected_job_counts = job_counts
+        # Parse job counts for accurate pending job inference. Always replace
+        # (clearing to None when the latest log has no Job stats yet) so counts
+        # from a previous run can't linger and be inferred onto a new run.
+        self._estimator.expected_job_counts = parse_job_stats_counts_from_log(log_path) or None
 
         # Parse "Provided cores: N" for definitive parallelism info
         cores = parse_cores_from_log(log_path)
@@ -3117,6 +3117,27 @@ class WorkflowMonitorTUI:
             cutoff_time=self._cutoff_time,
             log_reader=reader,
         )
+
+        # Infer total_jobs from the Job stats table when the progress line
+        # hasn't appeared yet (it only appears after the first completion).
+        # This lets the pending panel show correct counts immediately.
+        #
+        # Only infer for the latest/live run (log index 0). expected_job_counts is
+        # parsed from the latest log, so inferring while browsing a historical run
+        # would graft the live run's counts onto the wrong run's progress.
+        if (
+            progress.total_jobs == 0
+            and self._estimator is not None
+            and self._current_log_index == 0
+        ):
+            if not self._estimator.expected_job_counts:
+                self._init_current_rules_from_log()
+            if self._estimator.expected_job_counts:
+                from dataclasses import replace
+
+                inferred_total = sum(self._estimator.expected_job_counts.values())
+                if inferred_total > 0:
+                    progress = replace(progress, total_jobs=inferred_total)
 
         # Sync log reader's completed jobs to registry when events aren't available
         # This ensures the registry is the single source of truth regardless of

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2431,3 +2431,113 @@ class TestMaxVisibleRows:
         tui._layout_mode = LayoutMode.COMPACT
         compact_rows = tui._max_visible_rows(2)
         assert minimal_rows == compact_rows
+
+
+class TestPendingJobsBeforeCompletion:
+    """Tests that pending panel works before any job completes."""
+
+    def test_total_jobs_inferred_from_expected_counts(
+        self, tui_with_mocks: "WorkflowMonitorTUI"
+    ) -> None:
+        """total_jobs should be inferred from expected_job_counts when progress line
+        hasn't appeared yet (total_jobs == 0)."""
+        from unittest.mock import MagicMock
+
+        tui = tui_with_mocks
+        estimator = MagicMock()
+        estimator.expected_job_counts = {"align": 5, "sort": 3}
+        estimator.estimate_remaining.return_value = None
+        tui._estimator = estimator
+
+        # Simulate progress with total_jobs=0 (no progress line yet)
+        progress = make_workflow_progress(total_jobs=0, completed_jobs=0)
+
+        with patch.object(tui, "_read_new_events", return_value=[]):
+            with patch("snakesee.tui.monitor.parse_workflow_state", return_value=progress):
+                result_progress, _ = tui._poll_state()
+
+        assert result_progress.total_jobs == 8  # 5 + 3
+        assert result_progress.pending_jobs == 8  # all pending, none running/completed
+
+    def test_pending_count_accounts_for_running_jobs(
+        self, tui_with_mocks: "WorkflowMonitorTUI"
+    ) -> None:
+        """pending_jobs should decrease as running_jobs increases, even before first
+        completion."""
+        from unittest.mock import MagicMock
+
+        tui = tui_with_mocks
+        estimator = MagicMock()
+        estimator.expected_job_counts = {"align": 5, "sort": 3}
+        estimator.estimate_remaining.return_value = None
+        tui._estimator = estimator
+
+        running = [make_job_info(rule="align", job_id="1"), make_job_info(rule="align", job_id="2")]
+        progress = make_workflow_progress(total_jobs=0, completed_jobs=0, running_jobs=running)
+
+        with patch.object(tui, "_read_new_events", return_value=[]):
+            with patch("snakesee.tui.monitor.parse_workflow_state", return_value=progress):
+                result_progress, _ = tui._poll_state()
+
+        assert result_progress.total_jobs == 8
+        assert result_progress.pending_jobs == 6  # 8 - 2 running
+
+    def test_no_inference_without_estimator(self, tui_with_mocks: "WorkflowMonitorTUI") -> None:
+        """total_jobs stays 0 when there's no estimator to infer from."""
+        tui = tui_with_mocks
+        tui._estimator = None
+
+        progress = make_workflow_progress(total_jobs=0, completed_jobs=0)
+
+        with patch.object(tui, "_read_new_events", return_value=[]):
+            with patch("snakesee.tui.monitor.parse_workflow_state", return_value=progress):
+                result_progress, _ = tui._poll_state()
+
+        assert result_progress.total_jobs == 0
+
+    def test_no_override_when_progress_line_exists(
+        self, tui_with_mocks: "WorkflowMonitorTUI"
+    ) -> None:
+        """total_jobs from the progress line takes precedence over inferred value."""
+        from unittest.mock import MagicMock
+
+        tui = tui_with_mocks
+        estimator = MagicMock()
+        estimator.expected_job_counts = {"align": 5, "sort": 3}
+        estimator.estimate_remaining.return_value = None
+        tui._estimator = estimator
+
+        # total_jobs=10 from progress line (already parsed a completion)
+        progress = make_workflow_progress(total_jobs=10, completed_jobs=1)
+
+        with patch.object(tui, "_read_new_events", return_value=[]):
+            with patch("snakesee.tui.monitor.parse_workflow_state", return_value=progress):
+                result_progress, _ = tui._poll_state()
+
+        # Should keep the progress line value, not override with 8
+        assert result_progress.total_jobs == 10
+
+    def test_no_inference_in_historical_view(self, tui_with_mocks: "WorkflowMonitorTUI") -> None:
+        """total_jobs is not inferred when browsing a historical run (log index > 0).
+
+        expected_job_counts is parsed from the latest log, so inferring it onto an
+        older run's progress would show the wrong total.
+        """
+        from unittest.mock import MagicMock
+
+        tui = tui_with_mocks
+        estimator = MagicMock()
+        estimator.expected_job_counts = {"align": 5, "sort": 3}
+        estimator.estimate_remaining.return_value = None
+        tui._estimator = estimator
+        # Browsing a historical run, not the latest/live one.
+        tui._current_log_index = 1
+
+        progress = make_workflow_progress(total_jobs=0, completed_jobs=0)
+
+        with patch.object(tui, "_read_new_events", return_value=[]):
+            with patch("snakesee.tui.monitor.parse_workflow_state", return_value=progress):
+                result_progress, _ = tui._poll_state()
+
+        # No inference in historical view; total_jobs stays 0.
+        assert result_progress.total_jobs == 0


### PR DESCRIPTION
## Summary
- Infer `total_jobs` from the Job stats table (`expected_job_counts`) when the Snakemake progress line hasn't appeared yet (it only appears after the first completion)
- This lets the pending panel show correct counts and per-rule breakdown immediately, updating as jobs start running
- Falls back gracefully if the Job stats table isn't available yet

Closes #(none — discovered during usage)

## Test plan
- [x] 4 new tests in `TestPendingJobsBeforeCompletion`
- [x] `total_jobs` inferred from expected counts when progress line absent
- [x] Pending count accounts for running jobs before first completion
- [x] No inference without estimator
- [x] Progress line value takes precedence when available
- [x] Full test suite passes (1086 tests)
- [ ] Manual: start snakesee on a fresh workflow, verify pending panel populates immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pending job panel now displays inferred job counts earlier during live runs, improving visibility before initial progress lines appear.

* **Bug Fixes**
  * Prevented stale expected job counts from carrying over between log parses so inferred totals reflect current log state.

* **Tests**
  * Added tests covering pending-job inference behavior, historical-run disabling, and interactions with running-job counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/snakesee/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->