### PR TITLE
chore: release snakesee 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snakesee"
-version = "0.7.0"
+version = "0.8.0"
 description = "A terminal UI for monitoring Snakemake workflows"
 authors = [{ name = "Nils Homer", email = "nils@fulcrumgenomics.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1826,7 +1826,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "snakesee"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "defopt" },
@@ -1872,7 +1872,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rich-pixels", specifier = ">=3.0.1" },
     { name = "snakemake", specifier = ">=8.0.0" },
-    { name = "textual", specifier = ">=0.80" },
+    { name = "textual", specifier = ">=0.80.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Bumps `snakesee` to 0.8.0 for release.

Changes since 0.7.0:
- feat: migrate TUI to Textual and add demo subcommand (#65)
- feat: TUI quality-of-life improvements (#60)
- feat: segmented progress bar with running/pending counts (#57)
- feat: dynamic table row counts based on terminal height (#61)
- fix: show pending jobs before first completion (#64)
- perf: cache metadata directory scans to avoid re-stat-ing thousands of files (#58)
- docs: add product screenshot of the TUI (#67), add Fulcrum Genomics branding to README (#63)

After merge, the `0.8.0` tag will be pushed to trigger the publish workflow (PyPI + GitHub Release).

No logger plugin changes since `snakesee-logger-0.1.1`, so no plugin release this cycle.