### PR TITLE
ci: grant called tests workflow its required permissions in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,11 @@ jobs:
     name: tests
     needs: on-main-branch-check
     if: ${{ needs.on-main-branch-check.outputs.on_main == 'true' }}
+    # The called workflow requests these permissions at its top level, so the
+    # caller must grant them explicitly or the run fails at startup.
+    permissions:
+      contents: read
+      pull-requests: write
     uses: "./.github/workflows/tests.yml"
 
   build-sdist:


### PR DESCRIPTION
The `publish` workflow failed at startup on the `0.8.0` tag with:

> Error calling workflow '.github/workflows/tests.yml'. The workflow is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

The reusable `tests.yml` declares `permissions: {contents: read, pull-requests: write}` at its top level, and a calling workflow must grant at least what the called workflow requests — the default token policy only allows read. This grants the permissions explicitly on the calling `tests` job.

Unblocks the 0.8.0 release: the tag was deleted after the startup failure and will be re-pushed once this lands.