### PR TITLE
chore: update repository references from nh13 to fg-labs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,4 +50,4 @@ jobs:
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: nh13/snakesee
+          slug: fg-labs/snakesee

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to snakesee!
 
 ```bash
 # Clone the repository
-git clone https://github.com/nh13/snakesee.git
+git clone https://github.com/fg-labs/snakesee.git
 cd snakesee
 
 # Install development environment
@@ -36,7 +36,7 @@ pixi run docs
 
 ```bash
 # Clone the repository
-git clone https://github.com/nh13/snakesee.git
+git clone https://github.com/fg-labs/snakesee.git
 cd snakesee
 
 # Create virtual environment and install
@@ -153,4 +153,4 @@ The plugin writes events to `.snakesee_events.jsonl` which snakesee reads via `s
 
 ## Questions?
 
-Open an issue at https://github.com/nh13/snakesee/issues
+Open an issue at https://github.com/fg-labs/snakesee/issues

--- a/README.md
+++ b/README.md
@@ -417,11 +417,11 @@ This codebase was written with the assistance of AI (Claude). All code has been 
 [type-check-badge]: https://img.shields.io/badge/type%20checked-mypy-blue
 [type-check-link]: https://mypy.readthedocs.io/
 [license-badge]: https://img.shields.io/badge/license-MIT-blue
-[license-link]: https://github.com/nh13/snakesee/blob/main/LICENSE
-[tests-badge]: https://github.com/nh13/snakesee/actions/workflows/tests.yml/badge.svg
-[tests-link]: https://github.com/nh13/snakesee/actions/workflows/tests.yml
-[codecov-badge]: https://codecov.io/gh/nh13/snakesee/graph/badge.svg
-[codecov-link]: https://codecov.io/gh/nh13/snakesee
+[license-link]: https://github.com/fg-labs/snakesee/blob/main/LICENSE
+[tests-badge]: https://github.com/fg-labs/snakesee/actions/workflows/tests.yml/badge.svg
+[tests-link]: https://github.com/fg-labs/snakesee/actions/workflows/tests.yml
+[codecov-badge]: https://codecov.io/gh/fg-labs/snakesee/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/fg-labs/snakesee
 [docs-badge]: https://readthedocs.org/projects/snakesee/badge/?version=latest
 [docs-link]: https://snakesee.readthedocs.io/en/latest/
 [pypi-badge]: https://img.shields.io/pypi/v/snakesee

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -17,7 +17,7 @@ git push origin X.Y.Z
 
 # 4. Verify
 #    - PyPI: https://pypi.org/project/snakesee/
-#    - GitHub: https://github.com/nh13/snakesee/releases
+#    - GitHub: https://github.com/fg-labs/snakesee/releases
 #    - Install: pip install snakesee==X.Y.Z
 ```
 
@@ -33,7 +33,7 @@ CI automatically:
 
 Before releasing, ensure:
 - [ ] All tests pass: `pixi run check` or `uv run poe check-all`
-- [ ] Coverage meets 95% threshold
+- [ ] Coverage meets 80% threshold
 - [ ] Documentation builds: `pixi run docs`
 - [ ] All PRs for this release are merged to `main`
 
@@ -70,7 +70,7 @@ git push origin snakesee-logger-X.Y.Z
 
 # 4. Verify
 #    - PyPI: https://pypi.org/project/snakemake-logger-plugin-snakesee/
-#    - GitHub: https://github.com/nh13/snakesee/releases
+#    - GitHub: https://github.com/fg-labs/snakesee/releases
 #    - Install: pip install snakemake-logger-plugin-snakesee==X.Y.Z
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,6 @@ snakesee status
 
 ## Links
 
-- [GitHub Repository](https://github.com/nh13/snakesee)
+- [GitHub Repository](https://github.com/fg-labs/snakesee)
 - [PyPI Package](https://pypi.org/project/snakesee/)
-- [Issue Tracker](https://github.com/nh13/snakesee/issues)
+- [Issue Tracker](https://github.com/fg-labs/snakesee/issues)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,7 +42,7 @@ mamba install -c bioconda snakesee
 Clone and install in development mode:
 
 ```bash
-git clone https://github.com/nh13/snakesee.git
+git clone https://github.com/fg-labs/snakesee.git
 cd snakesee
 pip install -e '.[logo]'
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ theme:
   navstyle: dark
   include_sidebar: true
   collapse_navigation: false
-repo_url: https://github.com/nh13/snakesee
+repo_url: https://github.com/fg-labs/snakesee
 plugins:
   - autorefs:
       resolve_closest: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/nh13/snakesee"
-Repository = "https://github.com/nh13/snakesee"
+Homepage = "https://github.com/fg-labs/snakesee"
+Repository = "https://github.com/fg-labs/snakesee"
 Documentation = "https://snakesee.readthedocs.io"
-"Bug Tracker" = "https://github.com/nh13/snakesee/issues"
+"Bug Tracker" = "https://github.com/fg-labs/snakesee/issues"
 
 [project.scripts]
 snakesee = "snakesee.cli:main"

--- a/snakemake-logger-plugin-snakesee/README.md
+++ b/snakemake-logger-plugin-snakesee/README.md
@@ -1,6 +1,6 @@
 # snakemake-logger-plugin-snakesee
 
-A Snakemake logger plugin that integrates with [snakesee](https://github.com/nh13/snakesee) for enhanced workflow monitoring.
+A Snakemake logger plugin that integrates with [snakesee](https://github.com/fg-labs/snakesee) for enhanced workflow monitoring.
 
 ## Overview
 

--- a/snakemake-logger-plugin-snakesee/pyproject.toml
+++ b/snakemake-logger-plugin-snakesee/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = ["snakemake-interface-logger-plugins>=1.0.0"]
 dev = ["pytest>=7.4.0", "mypy>=1.10.0", "ruff>=0.6.0"]
 
 [project.urls]
-Homepage = "https://github.com/nh13/snakesee"
-Repository = "https://github.com/nh13/snakesee"
+Homepage = "https://github.com/fg-labs/snakesee"
+Repository = "https://github.com/fg-labs/snakesee"
 
 [project.entry-points."snakemake.plugins.logger"]
 snakesee = "snakemake_logger_plugin_snakesee:LogHandler"


### PR DESCRIPTION
The repository moved from `nh13/snakesee` to `fg-labs/snakesee` (this surfaced during the 0.8.0 release via the PyPI trusted-publisher mismatch). This updates the remaining stale references:

- GitHub URLs in `pyproject.toml` (both packages), `mkdocs.yml`, `README.md`, `RELEASE_STEPS.md`, `CONTRIBUTING.md`, and `docs/`
- Codecov badge in `README.md` and upload `slug` in `tests.yml`
- `RELEASE_STEPS.md` coverage threshold claim corrected from 95% to the configured 80% (`fail_under = 80` in `pyproject.toml`)

Note: the Codecov slug change is exercised by this PR's own CI run. If the upload step fails, the `CODECOV_TOKEN` secret may need to be refreshed from the Codecov project settings for `fg-labs/snakesee`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository links and references throughout documentation, guides, and installation instructions.

* **Chores**
  * Updated project configuration metadata across configuration files and GitHub Actions workflow for code coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->