### PR TITLE
ci: bump action pins to Node 24-capable versions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,7 +24,9 @@ jobs:
         SNAKEMAKE_VERSION: ["8.30.0", "9.14.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7

--- a/.github/workflows/publish-logger-plugin.yml
+++ b/.github/workflows/publish-logger-plugin.yml
@@ -17,9 +17,10 @@ jobs:
       - name: git config --global remote.origin.followRemoteHEAD never
         run: git config --global remote.origin.followRemoteHEAD never
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308 # v1
         id: contains_tag
@@ -36,7 +37,9 @@ jobs:
       matrix:
         PYTHON_VERSION: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -61,9 +64,10 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -76,7 +80,7 @@ jobs:
         working-directory: snakemake-logger-plugin-snakesee
         run: uv build --sdist
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: logger-plugin-sdist
           path: snakemake-logger-plugin-snakesee/dist/*.tar.gz
@@ -88,7 +92,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: packages
           pattern: 'logger-plugin-*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,10 @@ jobs:
       - name: git config --global remote.origin.followRemoteHEAD never
         run: git config --global remote.origin.followRemoteHEAD never
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308 # v1
         id: contains_tag
@@ -43,9 +44,10 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -57,7 +59,7 @@ jobs:
       - name: Build package
         run: uv build --sdist
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: snakesee-sdist
           path: dist/*.tar.gz
@@ -69,7 +71,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: packages
           pattern: 'snakesee-*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,9 @@ jobs:
         PYTHON_VERSION: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7


### PR DESCRIPTION
GitHub Actions forces Node 24 by default on **June 16, 2026** (Node 20 removed from runners September 16, 2026), and the 0.8.0 publish run emitted deprecation annotations for four actions still on Node 20. This bumps each to its latest release, pinned by commit hash per repo convention:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6.0.3 (`df4cb1c`) |
| `actions/upload-artifact` | v4 | v7.0.1 (`043fb46`) |
| `actions/download-artifact` | v4 | v8.0.1 (`3e5f45b`) |
| `softprops/action-gh-release` | v2 | v3.0.0 (`b430933`) |

Compatibility checked against each new version's `action.yml`: every input our workflows use (`ref`, `fetch-depth`, `name`, `path`, `pattern`, `merge-multiple`, `body`, `draft`, `prerelease`) exists unchanged, and `checkout` v6 keeps `persist-credentials: true` as default.

Left alone: `rickstaa/action-contains-tag` and `orhun/git-cliff-action` (Docker-based, no Node runtime; contains-tag is already at its latest release), `astral-sh/setup-uv` v7 and `codecov/codecov-action` v5 (already Node 24), `pypa/gh-action-pypi-publish` (Docker-based).

Note: the `tests.yml`/`integration-tests.yml` changes are exercised by this PR's CI; the `publish*.yml` changes only run on the next release tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pinned GitHub Actions versions used across CI/CD and publishing workflows (checkout, artifact upload/download, release/publish steps) to newer revisions for improved pipeline reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->