### PR TITLE
feat: remote executor support — QUEUED state, timing, and console links

### DIFF
--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/events.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/events.py
@@ -1,7 +1,7 @@
 """Event types and dataclasses for snakesee logger plugin."""
 
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from enum import Enum
 from typing import Any
 
@@ -11,13 +11,14 @@ class EventType(str, Enum):
 
     WORKFLOW_STARTED = "workflow_started"
     JOB_SUBMITTED = "job_submitted"
+    JOB_QUEUED = "job_queued"
     JOB_STARTED = "job_started"
     JOB_FINISHED = "job_finished"
     JOB_ERROR = "job_error"
     PROGRESS = "progress"
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class SnakeseeEvent:
     """A single event from the Snakemake workflow.
 
@@ -36,6 +37,18 @@ class SnakeseeEvent:
         completed_jobs: Number of completed jobs (for progress events).
         total_jobs: Total number of jobs (for progress events).
         workflow_id: Unique workflow identifier.
+        executor: Remote executor identifier (e.g. "aws-batch"), if applicable.
+        external_jobid: External executor job id/ARN, for remote jobs.
+        remote_status: Raw backend status string (e.g. "RUNNING"), for remote jobs.
+        queued_at: Epoch seconds the job entered the remote queue, if known.
+        started_at: Epoch seconds the job began executing on a remote node, if known.
+        stopped_at: Epoch seconds the job stopped executing remotely, if known.
+        attempt: 1-based attempt number for retried/preempted remote jobs.
+        exit_code: Container/process exit code for a finished remote job.
+        status_reason: Backend-provided reason string (e.g. failure cause).
+        queue: The remote queue the job was routed to, if known.
+        log_stream: Backend log stream identifier (e.g. CloudWatch stream).
+        region: Cloud region, used to build console deep links.
     """
 
     event_type: EventType
@@ -52,6 +65,19 @@ class SnakeseeEvent:
     completed_jobs: int | None = None
     total_jobs: int | None = None
     workflow_id: str | None = None
+    # Remote-executor enrichment (all optional; absent for local jobs).
+    executor: str | None = None
+    external_jobid: str | None = None
+    remote_status: str | None = None
+    queued_at: float | None = None
+    started_at: float | None = None
+    stopped_at: float | None = None
+    attempt: int | None = None
+    exit_code: int | None = None
+    status_reason: str | None = None
+    queue: str | None = None
+    log_stream: str | None = None
+    region: str | None = None
 
     def to_json(self) -> str:
         """Serialize to compact JSON string.
@@ -80,4 +106,9 @@ class SnakeseeEvent:
         """
         data = json.loads(json_str)
         data["event_type"] = EventType(data["event_type"])
+        # Drop unknown keys for forward compatibility, mirroring the reader side:
+        # a newer event file must not raise TypeError when parsed by an older
+        # build that doesn't model some field yet.
+        known = {f.name for f in fields(cls)}
+        data = {k: v for k, v in data.items() if k in known}
         return cls(**data)

--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/handler.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/handler.py
@@ -8,6 +8,7 @@ from typing import Any
 from snakemake_interface_logger_plugins.base import LogHandlerBase
 
 from snakemake_logger_plugin_snakesee.events import EventType, SnakeseeEvent
+from snakemake_logger_plugin_snakesee.remote_adapter import WIRE_KEY, event_from_payload
 from snakemake_logger_plugin_snakesee.settings import LogHandlerSettings
 from snakemake_logger_plugin_snakesee.writer import EventWriter
 
@@ -101,11 +102,23 @@ class LogHandler(LogHandlerBase):
         Args:
             record: The log record from Snakemake.
         """
+        timestamp = time.time()
+
+        # Remote executors attach a structured remote-job-state payload to an
+        # ordinary log record (under ``snakesee_remote``) instead of using a
+        # Snakemake LogEvent — the LogEvent enum is fixed upstream and an
+        # executor cannot extend it. Handle that channel first; such records may
+        # have no ``event`` attribute at all.
+        remote_payload = getattr(record, WIRE_KEY, None)
+        if remote_payload is not None:
+            remote_event = event_from_payload(remote_payload, timestamp)
+            if remote_event is not None:
+                self._writer.write(remote_event)
+            return
+
         event = getattr(record, "event", None)
         if event is None:
             return
-
-        timestamp = time.time()
 
         # Map LogEvent to handler methods
         if event == LogEvent.JOB_INFO:

--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/remote_adapter.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/remote_adapter.py
@@ -1,0 +1,126 @@
+"""Adapter from the remote-job-state wire contract to snakesee events.
+
+A remote executor (AWS Batch, SLURM, ...) attaches a structured payload to one
+of its log records under the well-known key :data:`WIRE_KEY`. This adapter is
+the *single* place in the plugin that knows the wire shape: it validates the
+payload and translates it into a :class:`SnakeseeEvent` enriched with remote
+fields. Keeping that knowledge here means the rest of the plugin — and all of
+snakesee downstream — is insulated from the contract's exact wire format, which
+makes evolving the contract (or swapping it for a future standard upstream
+event) a localized change.
+
+This mirrors :mod:`snakesee.remote` on the reader side. The two are deliberately
+independent (the plugin must not depend on snakesee); the shared contract is the
+spec, and each side implements it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from snakemake_logger_plugin_snakesee.events import EventType, SnakeseeEvent
+
+# Log-record attribute the executor uses to carry the payload.
+WIRE_KEY: Final[str] = "snakesee_remote"
+
+# Wire schema versions this plugin understands.
+SUPPORTED_SCHEMA_VERSIONS: Final[frozenset[int]] = frozenset({1})
+
+# Normalized phase string -> snakesee event type.
+_PHASE_TO_EVENT: Final[dict[str, EventType]] = {
+    "queued": EventType.JOB_QUEUED,
+    "running": EventType.JOB_STARTED,
+    "succeeded": EventType.JOB_FINISHED,
+    "failed": EventType.JOB_ERROR,
+}
+
+
+def event_from_payload(payload: Any, timestamp: float) -> SnakeseeEvent | None:
+    """Translate a remote-state wire payload into a SnakeseeEvent.
+
+    Never raises on bad input: malformed or unsupported payloads return None so
+    a faulty or future executor cannot break event emission.
+
+    Args:
+        payload: The decoded wire object (expected to be a mapping).
+        timestamp: Event timestamp to stamp on the resulting event.
+
+    Returns:
+        An enriched SnakeseeEvent, or None if the payload is not a supported,
+        well-formed contract instance.
+    """
+    if not isinstance(payload, dict):
+        return None
+
+    if payload.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS:
+        return None
+
+    jobid = payload.get("jobid")
+    executor = payload.get("executor")
+    phase = payload.get("phase")
+    if jobid is None or executor is None or phase is None:
+        return None
+    if isinstance(jobid, bool) or not isinstance(jobid, int):
+        return None
+
+    event_type = _PHASE_TO_EVENT.get(str(phase))
+    if event_type is None:
+        return None
+
+    started_at = _opt_float(payload.get("started_at"))
+    stopped_at = _opt_float(payload.get("stopped_at"))
+
+    # Prefer an explicit execution window for duration; only meaningful on a
+    # terminal event where both ends are known.
+    duration: float | None = None
+    if event_type in (EventType.JOB_FINISHED, EventType.JOB_ERROR):
+        if started_at is not None and stopped_at is not None:
+            duration = max(0.0, stopped_at - started_at)
+
+    status_reason = _opt_str(payload.get("status_reason"))
+
+    return SnakeseeEvent(
+        event_type=event_type,
+        timestamp=timestamp,
+        job_id=jobid,
+        executor=str(executor),
+        external_jobid=_opt_str(payload.get("external_jobid")),
+        remote_status=_opt_str(payload.get("remote_status")),
+        queued_at=_opt_float(payload.get("queued_at")),
+        started_at=started_at,
+        stopped_at=stopped_at,
+        attempt=_opt_int(payload.get("attempt")),
+        exit_code=_opt_int(payload.get("exit_code")),
+        status_reason=status_reason,
+        queue=_opt_str(payload.get("queue")),
+        log_stream=_opt_str(payload.get("log_stream")),
+        region=_opt_str(payload.get("region")),
+        duration=duration,
+        # Surface the failure reason as the error message for JOB_ERROR events.
+        error_message=status_reason if event_type == EventType.JOB_ERROR else None,
+    )
+
+
+def _opt_str(value: Any) -> str | None:
+    """Coerce an optional value to str, preserving None."""
+    return None if value is None else str(value)
+
+
+def _opt_int(value: Any) -> int | None:
+    """Coerce an optional value to int, returning None on failure."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _opt_float(value: Any) -> float | None:
+    """Coerce an optional value to float, returning None on failure."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/snakemake-logger-plugin-snakesee/tests/test_events.py
+++ b/snakemake-logger-plugin-snakesee/tests/test_events.py
@@ -38,6 +38,15 @@ class TestSnakeseeEvent:
         assert event.timestamp == 1234567890.123
         assert event.job_id is None
 
+    def test_event_is_immutable(self) -> None:
+        """Test that events are frozen — mutation after creation must raise."""
+        event = SnakeseeEvent(
+            event_type=EventType.PROGRESS,
+            timestamp=1234567890.123,
+        )
+        with pytest.raises(AttributeError):
+            event.timestamp = 0.0  # type: ignore[misc]
+
     def test_full_job_event(self) -> None:
         """Test creating event with all job-related fields."""
         event = SnakeseeEvent(
@@ -115,6 +124,16 @@ class TestSnakeseeEvent:
         assert event.job_id == 42
         assert event.rule_name == "align"
         assert event.wildcards == {"sample": "A"}
+
+    def test_from_json_ignores_unknown_keys(self) -> None:
+        """Forward compat: unknown keys from a newer build must not raise."""
+        json_str = (
+            '{"event_type":"job_finished","timestamp":1.0,"job_id":7,'
+            '"some_future_field":{"x":1},"another":42}'
+        )
+        event = SnakeseeEvent.from_json(json_str)
+        assert event.event_type == EventType.JOB_FINISHED
+        assert event.job_id == 7
 
     def test_roundtrip(self) -> None:
         """Test that serialization round-trips correctly."""

--- a/snakemake-logger-plugin-snakesee/tests/test_remote_adapter.py
+++ b/snakemake-logger-plugin-snakesee/tests/test_remote_adapter.py
@@ -1,0 +1,133 @@
+"""Tests for the remote-job-state adapter and the handler's emit() hook."""
+
+import logging
+from typing import Any
+
+from snakemake_logger_plugin_snakesee.events import EventType
+from snakemake_logger_plugin_snakesee.remote_adapter import WIRE_KEY, event_from_payload
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "schema_version": 1,
+        "kind": "state",
+        "jobid": 7,
+        "executor": "aws-batch",
+        "phase": "running",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestEventFromPayload:
+    """Translation of wire payloads into SnakeseeEvents."""
+
+    def test_running_maps_to_job_started(self) -> None:
+        event = event_from_payload(_payload(phase="running"), timestamp=142.0)
+        assert event is not None
+        assert event.event_type == EventType.JOB_STARTED
+        assert event.job_id == 7
+        assert event.executor == "aws-batch"
+        assert event.timestamp == 142.0
+
+    def test_queued_maps_to_job_queued(self) -> None:
+        event = event_from_payload(_payload(phase="queued", queued_at=100.0), timestamp=100.0)
+        assert event is not None
+        assert event.event_type == EventType.JOB_QUEUED
+        assert event.queued_at == 100.0
+
+    def test_succeeded_maps_to_finished_with_duration(self) -> None:
+        event = event_from_payload(
+            _payload(phase="succeeded", started_at=142.0, stopped_at=200.0, exit_code=0),
+            timestamp=200.0,
+        )
+        assert event is not None
+        assert event.event_type == EventType.JOB_FINISHED
+        assert event.duration == 58.0
+        assert event.exit_code == 0
+
+    def test_failed_maps_to_error_with_reason(self) -> None:
+        event = event_from_payload(
+            _payload(phase="failed", status_reason="OOM killed", exit_code=137),
+            timestamp=200.0,
+        )
+        assert event is not None
+        assert event.event_type == EventType.JOB_ERROR
+        assert event.error_message == "OOM killed"
+        assert event.status_reason == "OOM killed"
+        assert event.exit_code == 137
+
+    def test_external_id_and_region_carried(self) -> None:
+        event = event_from_payload(
+            _payload(external_jobid="arn:...:job/abc", region="us-east-1", queue="gv-spot"),
+            timestamp=1.0,
+        )
+        assert event is not None
+        assert event.external_jobid == "arn:...:job/abc"
+        assert event.region == "us-east-1"
+        assert event.queue == "gv-spot"
+
+    def test_unsupported_version_returns_none(self) -> None:
+        assert event_from_payload(_payload(schema_version=2), timestamp=1.0) is None
+
+    def test_unknown_phase_returns_none(self) -> None:
+        assert event_from_payload(_payload(phase="bogus"), timestamp=1.0) is None
+
+    def test_non_mapping_returns_none(self) -> None:
+        assert event_from_payload(None, timestamp=1.0) is None
+        assert event_from_payload("nope", timestamp=1.0) is None
+
+
+class _FakeRecord:
+    """Minimal stand-in for a logging record carrying a remote payload."""
+
+    def __init__(self, **attrs: Any) -> None:
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+class TestHandlerEmitHook:
+    """The handler routes remote-state records through the adapter."""
+
+    def _make_handler(self, tmp_path: Any) -> Any:
+        from snakemake_logger_plugin_snakesee.handler import LogHandler
+
+        handler = LogHandler.__new__(LogHandler)  # bypass plugin __init__ machinery
+
+        class _CapturingWriter:
+            def __init__(self) -> None:
+                self.events: list[Any] = []
+
+            def write(self, event: Any) -> None:
+                self.events.append(event)
+
+        handler._writer = _CapturingWriter()  # type: ignore[attr-defined]
+        return handler
+
+    def test_remote_record_emits_event(self, tmp_path: Any) -> None:
+        handler = self._make_handler(tmp_path)
+        record = _FakeRecord(**{WIRE_KEY: _payload(phase="running")})
+        handler.emit(record)
+        assert len(handler._writer.events) == 1
+        assert handler._writer.events[0].event_type == EventType.JOB_STARTED
+
+    def test_malformed_remote_record_emits_nothing(self, tmp_path: Any) -> None:
+        handler = self._make_handler(tmp_path)
+        record = _FakeRecord(**{WIRE_KEY: _payload(schema_version=999)})
+        handler.emit(record)
+        assert handler._writer.events == []
+
+    def test_record_without_marker_falls_through(self, tmp_path: Any) -> None:
+        # A record with neither the remote marker nor an event should be ignored.
+        handler = self._make_handler(tmp_path)
+        record = _FakeRecord(event=None)
+        handler.emit(record)
+        assert handler._writer.events == []
+
+    def test_remote_record_does_not_require_event_attr(self, tmp_path: Any, caplog: Any) -> None:
+        handler = self._make_handler(tmp_path)
+        # No `event` attribute at all — emit must not raise.
+        record = _FakeRecord(**{WIRE_KEY: _payload(phase="queued")})
+        with caplog.at_level(logging.ERROR):
+            handler.emit(record)
+        assert len(handler._writer.events) == 1

--- a/snakesee/events.py
+++ b/snakesee/events.py
@@ -8,6 +8,7 @@ accurate and timely job status information than log parsing.
 import logging
 import threading
 from dataclasses import dataclass
+from dataclasses import fields
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -28,6 +29,7 @@ class EventType(str, Enum):
 
     WORKFLOW_STARTED = "workflow_started"
     JOB_SUBMITTED = "job_submitted"
+    JOB_QUEUED = "job_queued"
     JOB_STARTED = "job_started"
     JOB_FINISHED = "job_finished"
     JOB_ERROR = "job_error"
@@ -55,6 +57,18 @@ class SnakeseeEvent:
         completed_jobs: Number of completed jobs (for progress events).
         total_jobs: Total number of jobs (for progress events).
         workflow_id: Unique workflow identifier.
+        executor: Remote executor identifier (e.g. "aws-batch"), if applicable.
+        external_jobid: External executor job id/ARN, for remote jobs.
+        remote_status: Raw backend status string (e.g. "RUNNING"), for remote jobs.
+        queued_at: Epoch seconds the job entered the remote queue, if known.
+        started_at: Epoch seconds the job began executing on a remote node, if known.
+        stopped_at: Epoch seconds the job stopped executing remotely, if known.
+        attempt: 1-based attempt number for retried/preempted remote jobs.
+        exit_code: Container/process exit code for a finished remote job.
+        status_reason: Backend-provided reason string (e.g. failure cause).
+        queue: The remote queue the job was routed to, if known.
+        log_stream: Backend log stream identifier (e.g. CloudWatch stream).
+        region: Cloud region, used to build console deep links.
     """
 
     event_type: EventType
@@ -71,6 +85,19 @@ class SnakeseeEvent:
     completed_jobs: int | None = None
     total_jobs: int | None = None
     workflow_id: str | None = None
+    # Remote-executor enrichment (all optional; absent for local jobs).
+    executor: str | None = None
+    external_jobid: str | None = None
+    remote_status: str | None = None
+    queued_at: float | None = None
+    started_at: float | None = None
+    stopped_at: float | None = None
+    attempt: int | None = None
+    exit_code: int | None = None
+    status_reason: str | None = None
+    queue: str | None = None
+    log_stream: str | None = None
+    region: str | None = None
 
     @classmethod
     def from_json(cls, json_str: str | bytes) -> "SnakeseeEvent":
@@ -98,6 +125,13 @@ class SnakeseeEvent:
             data["input_files"] = tuple(data["input_files"])
         if "output_files" in data and data["output_files"] is not None:
             data["output_files"] = tuple(data["output_files"])
+
+        # Drop unknown keys for forward compatibility: a newer plugin may emit
+        # fields this build of snakesee doesn't model yet, and cls(**data) would
+        # otherwise raise on the unexpected keyword. Skipping them lets an older
+        # reader keep working against a newer event stream.
+        known = {f.name for f in fields(cls)}
+        data = {k: v for k, v in data.items() if k in known}
 
         return cls(**data)
 

--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -47,6 +47,10 @@ class JobInfo:
         input_size: Total size of input files in bytes (None if unknown).
         threads: Number of threads allocated to this job (None if unknown).
         log_file: Path to the job's log file (parsed from snakemake log directive).
+        external_jobid: External executor job id/ARN (e.g. AWS Batch), if remote.
+        executor: Remote executor identifier (e.g. "aws-batch"), if applicable.
+        region: Cloud region, used to build console deep links (if known).
+        log_stream: Backend log stream identifier (e.g. CloudWatch stream), if known.
     """
 
     rule: str
@@ -58,6 +62,10 @@ class JobInfo:
     input_size: int | None = None
     threads: int | None = None
     log_file: Path | None = None
+    external_jobid: str | None = None
+    executor: str | None = None
+    region: str | None = None
+    log_stream: str | None = None
 
     @property
     def elapsed(self) -> float | None:

--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -51,6 +51,9 @@ class JobInfo:
         executor: Remote executor identifier (e.g. "aws-batch"), if applicable.
         region: Cloud region, used to build console deep links (if known).
         log_stream: Backend log stream identifier (e.g. CloudWatch stream), if known.
+        queued_at: Epoch seconds the job entered the remote queue, if known. For a
+            remote job, start_time is the true execution start, so the difference
+            is the queue wait.
     """
 
     rule: str
@@ -66,6 +69,19 @@ class JobInfo:
     executor: str | None = None
     region: str | None = None
     log_stream: str | None = None
+    queued_at: float | None = None
+
+    @property
+    def queue_wait(self) -> float | None:
+        """Seconds spent queued before execution began (remote jobs only).
+
+        Returns:
+            start_time - queued_at when both are known and non-negative, else None.
+        """
+        if self.queued_at is None or self.start_time is None:
+            return None
+        wait = self.start_time - self.queued_at
+        return wait if wait >= 0 else None
 
     @property
     def elapsed(self) -> float | None:
@@ -671,6 +687,7 @@ class WorkflowProgress:
         failed_jobs_list: List of failed job details (for --keep-going).
         incomplete_jobs_list: List of jobs that were in progress when workflow was interrupted.
         running_jobs: List of currently running jobs.
+        queued_jobs_list: List of jobs queued on a remote executor (awaiting a node).
         recent_completions: List of recently completed jobs.
         start_time: Unix timestamp when workflow started.
         log_file: Path to the current snakemake log file.
@@ -686,6 +703,7 @@ class WorkflowProgress:
     running_jobs: list[JobInfo] = field(default_factory=list)
     recent_completions: list[JobInfo] = field(default_factory=list)
     pending_jobs_list: list[JobInfo] = field(default_factory=list)
+    queued_jobs_list: list[JobInfo] = field(default_factory=list)
     start_time: float | None = None
     log_file: Path | None = None
 
@@ -715,13 +733,14 @@ class WorkflowProgress:
 
     @property
     def pending_jobs(self) -> int:
-        """Number of jobs not yet started (excludes failed, running, and incomplete)."""
+        """Number of jobs not yet started (excludes failed, running, queued, incomplete)."""
         return max(
             0,
             self.total_jobs
             - self.completed_jobs
             - self.failed_jobs
             - len(self.running_jobs)
+            - len(self.queued_jobs_list)
             - len(self.incomplete_jobs_list),
         )
 

--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -54,6 +54,7 @@ class JobInfo:
         queued_at: Epoch seconds the job entered the remote queue, if known. For a
             remote job, start_time is the true execution start, so the difference
             is the queue wait.
+        queue: The remote queue / compute environment the job was routed to, if known.
     """
 
     rule: str
@@ -70,6 +71,7 @@ class JobInfo:
     region: str | None = None
     log_stream: str | None = None
     queued_at: float | None = None
+    queue: str | None = None
 
     @property
     def queue_wait(self) -> float | None:

--- a/snakesee/parser/core.py
+++ b/snakesee/parser/core.py
@@ -1305,6 +1305,7 @@ def parse_workflow_state(
                 rule=ij.rule or "unknown",
                 start_time=ij.start_time,
                 output_file=ij.output_file,
+                external_jobid=ij.external_jobid,
             )
             for ij in backend.iterate_incomplete_jobs(min_start_time=start_time)
         ]

--- a/snakesee/remote_links.py
+++ b/snakesee/remote_links.py
@@ -1,0 +1,116 @@
+"""Builders for AWS console / CloudWatch deep links from remote job identifiers.
+
+These are pure string helpers: given an external AWS Batch job id (or ARN) and,
+where available, a region and log stream, they build the URLs a user can open to
+inspect the job in the AWS console or its logs in CloudWatch. Everything is
+``None``-tolerant — when there isn't enough information to build a meaningful
+link (most importantly, no region), the builder returns ``None`` and the caller
+simply shows the raw identifier instead.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import quote
+
+# arn:aws:batch:<region>:<account>:job/<job-id>
+_ARN_RE = re.compile(r"^arn:aws[\w-]*:batch:(?P<region>[^:]+):[^:]*:job/(?P<job_id>.+)$")
+
+# CloudWatch's URL fragment double-encodes path separators: "/" becomes "$252F".
+_DEFAULT_BATCH_LOG_GROUP = "/aws/batch/job"
+
+
+def batch_job_id_from(external_jobid: str | None) -> str | None:
+    """Return the bare AWS Batch job id, extracting it from an ARN if needed.
+
+    Args:
+        external_jobid: A Batch job ARN, a bare job id, or None.
+
+    Returns:
+        The bare job id, or None if the input is empty.
+    """
+    if not external_jobid:
+        return None
+    candidate = external_jobid.strip()
+    if not candidate:
+        return None
+    match = _ARN_RE.match(candidate)
+    if match:
+        return match.group("job_id").strip()
+    return candidate
+
+
+def region_from_arn(external_jobid: str | None) -> str | None:
+    """Return the region embedded in a Batch ARN, or None if not an ARN.
+
+    Args:
+        external_jobid: A Batch job ARN, a bare job id, or None.
+
+    Returns:
+        The region string, or None if the input is not an ARN.
+    """
+    if not external_jobid:
+        return None
+    match = _ARN_RE.match(external_jobid)
+    return match.group("region") if match else None
+
+
+def batch_console_url(external_jobid: str | None, region: str | None = None) -> str | None:
+    """Build the AWS Batch console job-detail URL.
+
+    The region is taken from the explicit argument, falling back to a region
+    embedded in the ARN. Without a region (e.g. a bare job id from the metadata
+    DB), no console URL can be built.
+
+    Args:
+        external_jobid: A Batch job ARN or bare job id.
+        region: Explicit region, or None to derive it from an ARN.
+
+    Returns:
+        A console URL, or None if there is not enough information.
+    """
+    job_id = batch_job_id_from(external_jobid)
+    if job_id is None:
+        return None
+    resolved_region = region or region_from_arn(external_jobid)
+    if not resolved_region:
+        return None
+    return (
+        f"https://{resolved_region}.console.aws.amazon.com/batch/home"
+        f"?region={resolved_region}#jobs/detail/{job_id}"
+    )
+
+
+def cloudwatch_url(
+    log_stream: str | None,
+    region: str | None,
+    log_group: str = _DEFAULT_BATCH_LOG_GROUP,
+) -> str | None:
+    """Build the CloudWatch Logs URL for a Batch job's log stream.
+
+    Args:
+        log_stream: The CloudWatch log stream name (e.g. from describe_jobs).
+        region: The AWS region; required to build the URL.
+        log_group: The log group; defaults to the Batch default ``/aws/batch/job``.
+
+    Returns:
+        A CloudWatch Logs URL, or None if region or stream are missing.
+    """
+    if not log_stream or not region:
+        return None
+    # The CloudWatch console fragment encodes the group/stream twice: each path
+    # separator and reserved character is percent-encoded, then the percent signs
+    # themselves are encoded ("%" -> "$25"), so "/" ends up as "$252F".
+    group_enc = _cw_encode(log_group)
+    stream_enc = _cw_encode(log_stream)
+    return (
+        f"https://{region}.console.aws.amazon.com/cloudwatch/home"
+        f"?region={region}#logsV2:log-groups/log-group/{group_enc}"
+        f"/log-events/{stream_enc}"
+    )
+
+
+def _cw_encode(value: str) -> str:
+    """Apply CloudWatch's double percent-encoding to a path component."""
+    once = quote(value, safe="")
+    return once.replace("%", "$25")

--- a/snakesee/state/job_registry.py
+++ b/snakesee/state/job_registry.py
@@ -47,6 +47,10 @@ class Job:
         threads: Number of threads allocated.
         input_size: Total input file size in bytes.
         log_file: Path to job's log file.
+        external_jobid: External executor job id/ARN (e.g. AWS Batch), if remote.
+        executor: Remote executor identifier (e.g. "aws-batch"), if applicable.
+        region: Cloud region, used to build console deep links (if known).
+        log_stream: Backend log stream identifier (e.g. CloudWatch stream), if known.
     """
 
     key: str
@@ -59,6 +63,10 @@ class Job:
     threads: int | None = None
     input_size: int | None = None
     log_file: Path | None = None
+    external_jobid: str | None = None
+    executor: str | None = None
+    region: str | None = None
+    log_stream: str | None = None
     stats_recorded: bool = False
 
     @property
@@ -92,6 +100,10 @@ class Job:
             input_size=self.input_size,
             threads=self.threads,
             log_file=self.log_file,
+            external_jobid=self.external_jobid,
+            executor=self.executor,
+            region=self.region,
+            log_stream=self.log_stream,
         )
 
     @classmethod
@@ -122,6 +134,10 @@ class Job:
             threads=job_info.threads,
             input_size=job_info.input_size,
             log_file=job_info.log_file,
+            external_jobid=job_info.external_jobid,
+            executor=job_info.executor,
+            region=job_info.region,
+            log_stream=job_info.log_stream,
         )
 
 

--- a/snakesee/state/job_registry.py
+++ b/snakesee/state/job_registry.py
@@ -23,6 +23,7 @@ class JobStatus(Enum):
 
     PENDING = "pending"
     SUBMITTED = "submitted"
+    QUEUED = "queued"
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
@@ -51,6 +52,7 @@ class Job:
         executor: Remote executor identifier (e.g. "aws-batch"), if applicable.
         region: Cloud region, used to build console deep links (if known).
         log_stream: Backend log stream identifier (e.g. CloudWatch stream), if known.
+        queued_at: Epoch seconds the job entered the remote queue, if known.
     """
 
     key: str
@@ -67,7 +69,21 @@ class Job:
     executor: str | None = None
     region: str | None = None
     log_stream: str | None = None
+    queued_at: float | None = None
     stats_recorded: bool = False
+
+    @property
+    def queue_wait(self) -> float | None:
+        """Seconds spent queued before execution began (remote jobs only).
+
+        For a remote job, ``start_time`` is the true execution start (from the
+        executor) and ``queued_at`` is when it entered the queue, so their
+        difference is the queue wait. Returns None when either is unknown.
+        """
+        if self.queued_at is None or self.start_time is None:
+            return None
+        wait = self.start_time - self.queued_at
+        return wait if wait >= 0 else None
 
     @property
     def elapsed(self) -> float | None:
@@ -104,6 +120,7 @@ class Job:
             executor=self.executor,
             region=self.region,
             log_stream=self.log_stream,
+            queued_at=self.queued_at,
         )
 
     @classmethod
@@ -138,6 +155,7 @@ class Job:
             executor=job_info.executor,
             region=job_info.region,
             log_stream=job_info.log_stream,
+            queued_at=job_info.queued_at,
         )
 
 
@@ -273,6 +291,11 @@ class JobRegistry:
         with self._lock:
             return [self._jobs[key] for key in self._by_status[JobStatus.SUBMITTED]]
 
+    def queued(self) -> list[Job]:
+        """Get all jobs queued on a remote executor (submitted, awaiting a node)."""
+        with self._lock:
+            return [self._jobs[key] for key in self._by_status[JobStatus.QUEUED]]
+
     def pending(self) -> list[Job]:
         """Get all pending jobs (not yet submitted)."""
         with self._lock:
@@ -304,6 +327,10 @@ class JobRegistry:
     def submitted_job_infos(self) -> list[JobInfo]:
         """Get submitted jobs as JobInfo for backward compatibility."""
         return [job.to_job_info() for job in self.submitted()]
+
+    def queued_job_infos(self) -> list[JobInfo]:
+        """Get queued (remote, awaiting node) jobs as JobInfo."""
+        return [job.to_job_info() for job in self.queued()]
 
     def clear(self) -> None:
         """Clear all jobs from the registry."""
@@ -379,6 +406,7 @@ class JobRegistry:
         # These don't have job_id/rule_name and would create synthetic "unknown" jobs
         if event.event_type not in {
             EventType.JOB_SUBMITTED,
+            EventType.JOB_QUEUED,
             EventType.JOB_STARTED,
             EventType.JOB_FINISHED,
             EventType.JOB_ERROR,
@@ -412,25 +440,59 @@ class JobRegistry:
                 if event.threads:
                     job.threads = event.threads
 
+            # Carry remote-executor enrichment onto the job whenever present, so
+            # the external id / links / queue timing survive across event types.
+            self._apply_remote_fields(job, event)
+
             old_status = job.status
 
-            # Update based on event type
+            # Update based on event type. For remote jobs the executor supplies
+            # the true execution-window timestamps (started_at/stopped_at); prefer
+            # them over the event emission time so duration excludes queue wait.
             if event.event_type == EventType.JOB_SUBMITTED:
                 job.status = JobStatus.SUBMITTED
+            elif event.event_type == EventType.JOB_QUEUED:
+                # Only move *forward* into QUEUED. Remote event streams can deliver
+                # out of order or re-deliver; a stale JOB_QUEUED arriving after the
+                # job already started/finished must not demote it back to QUEUED.
+                if job.status in (JobStatus.PENDING, JobStatus.SUBMITTED):
+                    job.status = JobStatus.QUEUED
+                # The queue timestamp is valid history regardless of the transition;
+                # if the executor didn't supply one, the event time is the best proxy.
+                if job.queued_at is None:
+                    job.queued_at = (
+                        event.queued_at if event.queued_at is not None else event.timestamp
+                    )
             elif event.event_type == EventType.JOB_STARTED:
                 job.status = JobStatus.RUNNING
-                job.start_time = event.timestamp
+                job.start_time = (
+                    event.started_at if event.started_at is not None else event.timestamp
+                )
                 if event.threads:
                     job.threads = event.threads
             elif event.event_type == EventType.JOB_FINISHED:
                 job.status = JobStatus.COMPLETED
-                job.end_time = event.timestamp
+                job.end_time = event.stopped_at if event.stopped_at is not None else event.timestamp
             elif event.event_type == EventType.JOB_ERROR:
                 job.status = JobStatus.FAILED
-                job.end_time = event.timestamp
+                job.end_time = event.stopped_at if event.stopped_at is not None else event.timestamp
 
             self._update_indexes_unlocked(job, old_status)
             return job
+
+    @staticmethod
+    def _apply_remote_fields(job: Job, event: SnakeseeEvent) -> None:
+        """Copy remote-executor fields from an event onto a job (when present)."""
+        if event.external_jobid is not None:
+            job.external_jobid = event.external_jobid
+        if event.executor is not None:
+            job.executor = event.executor
+        if event.region is not None:
+            job.region = event.region
+        if event.log_stream is not None:
+            job.log_stream = event.log_stream
+        if event.queued_at is not None and job.queued_at is None:
+            job.queued_at = event.queued_at
 
     def store_threads(self, job_id: str, threads: int) -> None:
         """Store thread count for a job by job_id.

--- a/snakesee/state/job_registry.py
+++ b/snakesee/state/job_registry.py
@@ -53,6 +53,7 @@ class Job:
         region: Cloud region, used to build console deep links (if known).
         log_stream: Backend log stream identifier (e.g. CloudWatch stream), if known.
         queued_at: Epoch seconds the job entered the remote queue, if known.
+        queue: The remote queue / compute environment the job was routed to, if known.
     """
 
     key: str
@@ -70,6 +71,7 @@ class Job:
     region: str | None = None
     log_stream: str | None = None
     queued_at: float | None = None
+    queue: str | None = None
     stats_recorded: bool = False
 
     @property
@@ -121,6 +123,7 @@ class Job:
             region=self.region,
             log_stream=self.log_stream,
             queued_at=self.queued_at,
+            queue=self.queue,
         )
 
     @classmethod
@@ -156,6 +159,7 @@ class Job:
             region=job_info.region,
             log_stream=job_info.log_stream,
             queued_at=job_info.queued_at,
+            queue=job_info.queue,
         )
 
 
@@ -491,6 +495,8 @@ class JobRegistry:
             job.region = event.region
         if event.log_stream is not None:
             job.log_stream = event.log_stream
+        if event.queue is not None:
+            job.queue = event.queue
         if event.queued_at is not None and job.queued_at is None:
             job.queued_at = event.queued_at
 

--- a/snakesee/state/rule_registry.py
+++ b/snakesee/state/rule_registry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass
 from dataclasses import field
+from statistics import median
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -24,6 +25,13 @@ def _make_empty_rule_stats(rule: str = "") -> RuleTimingStats:
     from snakesee.models import RuleTimingStats
 
     return RuleTimingStats(rule=rule)
+
+
+def _median(values: list[float] | None) -> float | None:
+    """Median of a list of values, or None if empty/None."""
+    if not values:
+        return None
+    return float(median(values))
 
 
 def _make_combination_key(wildcards: dict[str, str] | None, threads: int | None) -> str | None:
@@ -199,6 +207,11 @@ class RuleRegistry:
         self._rules: dict[str, RuleStatistics] = {}
         self._global_mean_cache: float | None = None
         self._cache_valid: bool = False
+        # Queue wait (remote executors only) is tracked separately from execution
+        # duration: a job's time spent queued before a node picks it up is a
+        # property of the queue/cluster, not the rule's compute cost.
+        self._queue_waits_by_rule: dict[str, list[float]] = {}
+        self._queue_waits_by_queue: dict[str, list[float]] = {}
 
     def __len__(self) -> int:
         """Return number of rules in registry."""
@@ -274,6 +287,47 @@ class RuleRegistry:
             wildcards=job.wildcards if job.wildcards else None,
             input_size=job.input_size,
         )
+
+    def record_queue_wait(self, rule: str, wait: float, queue: str | None = None) -> None:
+        """Record the queue wait for a completed remote job.
+
+        Queue wait is the time a job spent queued on a remote executor before a
+        node began executing it. It is kept separate from execution duration so
+        time estimates aren't inflated by queue contention.
+
+        Args:
+            rule: Rule name.
+            wait: Seconds spent queued. Non-positive values (e.g. clock skew) are
+                ignored.
+            queue: Optional queue/compute-environment name the job was routed to.
+        """
+        if wait <= 0:
+            return
+        with self._lock:
+            self._queue_waits_by_rule.setdefault(rule, []).append(wait)
+            if queue is not None:
+                self._queue_waits_by_queue.setdefault(queue, []).append(wait)
+
+    def queue_wait_for_rule(self, rule: str) -> float | None:
+        """Median observed queue wait for a rule, or None if no data."""
+        with self._lock:
+            return _median(self._queue_waits_by_rule.get(rule))
+
+    def queue_wait_count_for_rule(self, rule: str) -> int:
+        """Number of queue-wait samples recorded for a rule (0 if none)."""
+        with self._lock:
+            return len(self._queue_waits_by_rule.get(rule, []))
+
+    def queue_wait_for_queue(self, queue: str) -> float | None:
+        """Median observed queue wait for a named queue, or None if no data."""
+        with self._lock:
+            return _median(self._queue_waits_by_queue.get(queue))
+
+    def overall_queue_wait(self) -> float | None:
+        """Median queue wait across all rules, or None if no data."""
+        with self._lock:
+            all_waits = [w for waits in self._queue_waits_by_rule.values() for w in waits]
+            return _median(all_waits)
 
     def global_mean_duration(self) -> float:
         """Get global mean duration across all rules.

--- a/snakesee/tui/app.py
+++ b/snakesee/tui/app.py
@@ -454,11 +454,22 @@ class SnakeseeApp(App[None]):
         if event.cursor_row >= len(jobs):
             return
         job = jobs[event.cursor_row]
+
+        # Remote jobs (e.g. AWS Batch) may have no local log file but still carry
+        # an external id + console/CloudWatch links worth showing.
+        from snakesee.tui.renderables import make_remote_job_info
+
+        header_lines = make_remote_job_info(job)
+
         log_path = job.log_file
         if log_path is None:
+            if not header_lines:
+                return
+            # No local log, but remote info is available — show just that.
+            self.push_screen(JobLogScreen(None, [], header_lines=header_lines))
             return
         lines = self._data.read_log_tail(log_path, max_lines=500)
-        self.push_screen(JobLogScreen(log_path, lines))
+        self.push_screen(JobLogScreen(log_path, lines, header_lines=header_lines))
 
     def __init__(
         self,

--- a/snakesee/tui/data_source.py
+++ b/snakesee/tui/data_source.py
@@ -694,6 +694,38 @@ class WorkflowDataSource:
                 )
                 break
 
+    def _handle_job_queued_event(self, event: SnakeseeEvent) -> None:
+        """Handle JOB_QUEUED event - mark a remote job as queued (awaiting a node).
+
+        The registry already transitioned the job to QUEUED via ``apply_event``;
+        here we just ensure a job record exists with the rule name and remote
+        fields so it appears in the queued list. Queued jobs are deliberately not
+        added to ``running_jobs`` — that is the whole point of the distinction.
+        """
+        from snakesee.state.job_registry import Job
+        from snakesee.state.job_registry import JobStatus
+
+        if event.job_id is None:
+            return
+        job_id_str = str(event.job_id)
+
+        existing = self._workflow_state.jobs.get_by_job_id(job_id_str)
+        if existing is None:
+            new_job = Job(
+                key=job_id_str,
+                rule=event.rule_name or "unknown",
+                status=JobStatus.QUEUED,
+                job_id=job_id_str,
+                wildcards=dict(event.wildcards) if event.wildcards else {},
+                threads=event.threads,
+                external_jobid=event.external_jobid,
+                executor=event.executor,
+                region=event.region,
+                log_stream=event.log_stream,
+                queued_at=event.queued_at if event.queued_at is not None else event.timestamp,
+            )
+            self._workflow_state.jobs.add(new_job)
+
     def _handle_job_started_event(
         self,
         event: SnakeseeEvent,
@@ -706,10 +738,15 @@ class WorkflowDataSource:
             return
         job_id_str = str(event.job_id)
 
+        # For a remote job the executor reports the true execution start; prefer it
+        # over the event emission time so elapsed/duration/queue_wait exclude queue
+        # wait. Local jobs have no started_at and fall back to the event timestamp.
+        start = event.started_at if event.started_at is not None else event.timestamp
+
         # Transition job from SUBMITTED to RUNNING
         registry_job = self._workflow_state.jobs.get_by_job_id(job_id_str)
         if registry_job is not None:
-            registry_job.start_time = event.timestamp
+            registry_job.start_time = start
             self._workflow_state.jobs.set_status(registry_job, JobStatus.RUNNING)
 
         threads = event.threads or (registry_job.threads if registry_job else None)
@@ -718,7 +755,7 @@ class WorkflowDataSource:
                 running_jobs[i] = JobInfo(
                     rule=job.rule,
                     job_id=job.job_id,
-                    start_time=event.timestamp,
+                    start_time=start,
                     end_time=job.end_time,
                     output_file=job.output_file,
                     wildcards=event.wildcards_dict or job.wildcards,
@@ -735,7 +772,7 @@ class WorkflowDataSource:
                 JobInfo(
                     rule=rule,
                     job_id=job_id_str,
-                    start_time=event.timestamp,
+                    start_time=start,
                     wildcards=event.wildcards_dict,
                     threads=threads,
                 )
@@ -890,7 +927,9 @@ class WorkflowDataSource:
         """Apply event updates to enhance progress accuracy.
 
         Events from the logger plugin provide more accurate timing and
-        status information than log parsing.
+        status information than log parsing. For remote executors this also
+        populates ``queued_jobs_list`` (jobs awaiting a node) and keeps those
+        jobs out of ``running_jobs``.
 
         Args:
             progress: The current workflow progress from parsing.
@@ -918,6 +957,8 @@ class WorkflowDataSource:
                     new_completed = event.completed_jobs
             elif event.event_type == EventType.JOB_SUBMITTED:
                 self._handle_job_submitted_event(event, new_running_jobs)
+            elif event.event_type == EventType.JOB_QUEUED:
+                self._handle_job_queued_event(event)
             elif event.event_type == EventType.JOB_STARTED:
                 self._handle_job_started_event(event, new_running_jobs)
             elif event.event_type == EventType.JOB_FINISHED:
@@ -971,6 +1012,19 @@ class WorkflowDataSource:
                 new_running_jobs, all_completed, new_failed_list
             )
 
+        # Remote jobs that are queued (submitted to the executor, awaiting a node)
+        # are tracked separately so they don't masquerade as RUNNING. A job the log
+        # parser thinks is "running" but the registry knows is QUEUED is filtered
+        # out of the running list here.
+        queued_jobs_list = self._workflow_state.jobs.queued_job_infos()
+        queued_ids = {job.job_id for job in queued_jobs_list if job.job_id}
+        if queued_ids:
+            new_running_jobs = [j for j in new_running_jobs if j.job_id not in queued_ids]
+
+        # Fill remote fields (external id, links, queue timing) onto running jobs
+        # from the registry — log-parsed/started JobInfos don't carry them.
+        new_running_jobs = [self._enrich_remote_fields(job) for job in new_running_jobs]
+
         # Return updated progress
         return WorkflowProgress(
             workflow_dir=progress.workflow_dir,
@@ -982,8 +1036,35 @@ class WorkflowDataSource:
             running_jobs=new_running_jobs,
             recent_completions=new_completions,
             pending_jobs_list=pending_jobs_list,
+            queued_jobs_list=queued_jobs_list,
             start_time=progress.start_time,
             log_file=progress.log_file,
+        )
+
+    def _enrich_remote_fields(self, job: JobInfo) -> JobInfo:
+        """Return a copy of ``job`` with remote fields filled in from the registry.
+
+        Log-parsed and event-constructed running JobInfos don't carry the external
+        id / executor / region / log stream; the registry does. When the registry
+        has them for this job and the JobInfo lacks them, merge them in so the
+        running view can show the external id and links.
+        """
+        if job.job_id is None:
+            return job
+        registry_job = self._workflow_state.jobs.get_by_job_id(job.job_id)
+        if registry_job is None or registry_job.external_jobid is None:
+            return job
+        from dataclasses import replace
+
+        # Per-field merge that prefers values already on the JobInfo, so this never
+        # clobbers job-specific data and also backfills any partially-missing fields.
+        return replace(
+            job,
+            external_jobid=job.external_jobid or registry_job.external_jobid,
+            executor=job.executor or registry_job.executor,
+            region=job.region or registry_job.region,
+            log_stream=job.log_stream or registry_job.log_stream,
+            queued_at=job.queued_at if job.queued_at is not None else registry_job.queued_at,
         )
 
     def _update_rule_stats_from_completions(self, progress: WorkflowProgress) -> None:

--- a/snakesee/tui/data_source.py
+++ b/snakesee/tui/data_source.py
@@ -865,6 +865,13 @@ class WorkflowDataSource:
             wildcards=event.wildcards_dict,
         )
 
+        # For remote jobs, record the queue wait separately from execution time.
+        # The registry job carries queued_at/start_time/queue (the event may not).
+        if job is not None and job.queue_wait is not None:
+            self._workflow_state.rules.record_queue_wait(
+                event.rule_name, job.queue_wait, queue=job.queue
+            )
+
         # Mark as recorded
         if job is not None:
             job.stats_recorded = True
@@ -1064,6 +1071,7 @@ class WorkflowDataSource:
             executor=job.executor or registry_job.executor,
             region=job.region or registry_job.region,
             log_stream=job.log_stream or registry_job.log_stream,
+            queue=job.queue or registry_job.queue,
             queued_at=job.queued_at if job.queued_at is not None else registry_job.queued_at,
         )
 
@@ -1098,6 +1106,13 @@ class WorkflowDataSource:
                 wildcards=dict(registry_job.wildcards) if registry_job.wildcards else None,
                 input_size=registry_job.input_size,
             )
+
+            # For remote jobs, record the queue wait separately from execution time.
+            queue_wait = registry_job.queue_wait
+            if queue_wait is not None:
+                self._workflow_state.rules.record_queue_wait(
+                    registry_job.rule, queue_wait, queue=registry_job.queue
+                )
 
             # Mark as recorded for deduplication
             registry_job.stats_recorded = True

--- a/snakesee/tui/renderables.py
+++ b/snakesee/tui/renderables.py
@@ -13,6 +13,8 @@ from rich.text import Text
 if TYPE_CHECKING:
     from rich.console import RenderableType
 
+    from snakesee.models import JobInfo
+
 from snakesee.constants import DEFAULT_REFRESH_RATE
 from snakesee.constants import MIN_REFRESH_RATE
 from snakesee.events import EventReader
@@ -30,6 +32,40 @@ FG_GREEN = "#38b44a"
 
 # Fulcrum Genomics logo path (easter egg)
 FG_LOGO_PATH = Path(__file__).parent.parent / "assets" / "logo.png"
+
+
+def make_remote_job_info(job: "JobInfo") -> list[str]:
+    """Build display lines describing a remote job's external identifier and links.
+
+    For a job that ran on a remote executor (e.g. AWS Batch), this surfaces the
+    external job id and, when enough information is available, deep links to the
+    AWS console and CloudWatch logs. It degrades gracefully: a bare job id with
+    no region yields just the id line; a local job yields no lines at all.
+
+    Args:
+        job: The job to describe.
+
+    Returns:
+        A list of text lines (empty if the job has no external identifier).
+    """
+    if not job.external_jobid:
+        return []
+
+    from snakesee.remote_links import batch_console_url
+    from snakesee.remote_links import cloudwatch_url
+
+    label = job.executor or "remote"
+    lines = [f"{label} job: {job.external_jobid}"]
+
+    console = batch_console_url(job.external_jobid, region=job.region)
+    if console is not None:
+        lines.append(f"  console: {console}")
+
+    logs = cloudwatch_url(job.log_stream, region=job.region)
+    if logs is not None:
+        lines.append(f"  logs:    {logs}")
+
+    return lines
 
 
 def _truncate_path(path: str, max_len: int) -> str:

--- a/snakesee/tui/renderables.py
+++ b/snakesee/tui/renderables.py
@@ -57,6 +57,14 @@ def make_remote_job_info(job: "JobInfo") -> list[str]:
     label = job.executor or "remote"
     lines = [f"{label} job: {job.external_jobid}"]
 
+    if job.queue is not None:
+        lines.append(f"  queue:   {job.queue}")
+
+    # Queue wait is distinct from run time: it's how long the job waited for a node.
+    queue_wait = job.queue_wait
+    if queue_wait is not None:
+        lines.append(f"  queued for: {format_duration(queue_wait)}")
+
     console = batch_console_url(job.external_jobid, region=job.region)
     if console is not None:
         lines.append(f"  console: {console}")

--- a/snakesee/tui/renderables.py
+++ b/snakesee/tui/renderables.py
@@ -132,6 +132,13 @@ def make_header(
         header_text.append("  │  Elapsed: ")
         header_text.append(format_duration(progress.elapsed_seconds), style=FG_BLUE)
 
+    # Remote executors can have jobs queued (awaiting a node) but not yet running;
+    # surface that count so a "running" workflow waiting on the queue is honest.
+    queued_count = len(progress.queued_jobs_list)
+    if queued_count > 0:
+        header_text.append("  │  Queued: ")
+        header_text.append(str(queued_count), style="bold yellow")
+
     if paused:
         header_text.append("  │  ")
         header_text.append("PAUSED", style="bold yellow")

--- a/snakesee/tui/screens.py
+++ b/snakesee/tui/screens.py
@@ -84,16 +84,25 @@ class JobLogScreen(ModalScreen[None]):
         Binding("ctrl+r", "app.hard_refresh", show=False),
     ]
 
-    def __init__(self, log_path: Path | None, lines: list[str]) -> None:
+    def __init__(
+        self,
+        log_path: Path | None,
+        lines: list[str],
+        header_lines: list[str] | None = None,
+    ) -> None:
         """Initialize with the log path (shown as the border title) and tail lines.
 
         Args:
             log_path: Path to the job's log file, or None if unknown.
             lines: Tail lines (most recent at end) to render in the RichLog.
+            header_lines: Optional lines rendered above the log (e.g. a remote
+                job's external id and console/CloudWatch links). For a remote job
+                with no local log file, these may be the only content.
         """
         super().__init__()
         self._log_path = log_path
         self._lines = lines
+        self._header_lines = header_lines or []
 
     def compose(self) -> ComposeResult:
         """Yield a single RichLog widget that will be populated on mount."""
@@ -104,11 +113,20 @@ class JobLogScreen(ModalScreen[None]):
             wrap=False,
             auto_scroll=False,
         )
-        log.border_title = str(self._log_path) if self._log_path is not None else "job log"
+        if self._log_path is not None:
+            log.border_title = str(self._log_path)
+        elif self._header_lines:
+            log.border_title = "remote job"
+        else:
+            log.border_title = "job log"
         yield log
 
     def on_mount(self) -> None:
-        """Write the captured tail lines into the RichLog widget."""
+        """Write the optional header and captured tail lines into the RichLog widget."""
         log = self.query_one("#job-log", RichLog)
+        for line in self._header_lines:
+            log.write(line)
+        if self._header_lines and self._lines:
+            log.write("")  # blank separator between the remote header and the log tail
         for line in self._lines:
             log.write(line)

--- a/tests/test_app_screens.py
+++ b/tests/test_app_screens.py
@@ -95,6 +95,43 @@ async def test_job_log_screen_default_title_when_no_path(tmp_path: Path) -> None
         await pilot.press("q")
 
 
+async def test_job_log_screen_renders_remote_header(tmp_path: Path) -> None:
+    """A remote job with no local log shows only its header lines, titled 'remote job'."""
+    from textual.widgets import RichLog
+
+    header = ["aws-batch job: abc123", "  console: https://example"]
+
+    app = SnakeseeApp(workflow_dir=tmp_path)
+    async with app.run_test() as pilot:
+        screen = JobLogScreen(None, [], header_lines=header)
+        app.push_screen(screen)
+        await pilot.pause()
+        rich_log = screen.query_one("#job-log", RichLog)
+        assert rich_log.border_title == "remote job"
+        assert len(rich_log.lines) == len(header)
+        await pilot.press("escape")
+        await pilot.press("q")
+
+
+async def test_job_log_screen_header_plus_log_has_separator(tmp_path: Path) -> None:
+    """Header lines and log tail are separated by a blank line when both present."""
+    from textual.widgets import RichLog
+
+    header = ["aws-batch job: abc123"]
+    lines = ["log line one", "log line two"]
+
+    app = SnakeseeApp(workflow_dir=tmp_path)
+    async with app.run_test() as pilot:
+        screen = JobLogScreen(tmp_path / "job.log", lines, header_lines=header)
+        app.push_screen(screen)
+        await pilot.pause()
+        rich_log = screen.query_one("#job-log", RichLog)
+        # header (1) + blank separator (1) + log lines (2) = 4
+        assert len(rich_log.lines) == len(header) + 1 + len(lines)
+        await pilot.press("escape")
+        await pilot.press("q")
+
+
 async def test_toggle_pause_works_in_log_viewing_mode(tmp_path: Path) -> None:
     """The global pause toggle (p) still fires while a JobLogScreen is open.
 

--- a/tests/test_events_remote.py
+++ b/tests/test_events_remote.py
@@ -1,0 +1,77 @@
+"""Tests for remote-executor fields on SnakeseeEvent and forward-compat parsing."""
+
+import orjson
+
+from snakesee.events import EventType
+from snakesee.events import SnakeseeEvent
+
+
+class TestJobQueuedEventType:
+    """The new JOB_QUEUED event type."""
+
+    def test_job_queued_value(self) -> None:
+        """JOB_QUEUED has the expected wire string."""
+        assert EventType.JOB_QUEUED.value == "job_queued"
+
+
+class TestRemoteFields:
+    """Remote-executor enrichment fields on SnakeseeEvent."""
+
+    def test_remote_fields_default_none(self) -> None:
+        """Remote fields are optional and default to None."""
+        event = SnakeseeEvent(event_type=EventType.JOB_STARTED, timestamp=1.0)
+        assert event.external_jobid is None
+        assert event.executor is None
+        assert event.queued_at is None
+        assert event.started_at is None
+        assert event.stopped_at is None
+        assert event.attempt is None
+        assert event.exit_code is None
+        assert event.status_reason is None
+        assert event.queue is None
+        assert event.region is None
+        assert event.log_stream is None
+
+    def test_remote_fields_round_trip_from_json(self) -> None:
+        """Remote fields survive a JSON round trip."""
+        payload = {
+            "event_type": "job_started",
+            "timestamp": 142.0,
+            "job_id": 7,
+            "rule_name": "align",
+            "executor": "aws-batch",
+            "external_jobid": "arn:aws:batch:us-east-1:1:job/abc",
+            "remote_status": "RUNNING",
+            "queued_at": 100.0,
+            "started_at": 142.0,
+            "queue": "graviton-spot",
+            "region": "us-east-1",
+        }
+        event = SnakeseeEvent.from_json(orjson.dumps(payload))
+        assert event.event_type == EventType.JOB_STARTED
+        assert event.executor == "aws-batch"
+        assert event.external_jobid == "arn:aws:batch:us-east-1:1:job/abc"
+        assert event.remote_status == "RUNNING"
+        assert event.queued_at == 100.0
+        assert event.started_at == 142.0
+        assert event.queue == "graviton-spot"
+        assert event.region == "us-east-1"
+
+
+class TestUnknownKeyTolerance:
+    """from_json must ignore unknown keys for forward compatibility."""
+
+    def test_unknown_keys_dropped(self) -> None:
+        """A future field snakesee doesn't know about must not crash parsing."""
+        payload = {
+            "event_type": "job_finished",
+            "timestamp": 200.0,
+            "job_id": 7,
+            "duration": 58.0,
+            "some_future_field": {"nested": "value"},
+            "another_unknown": 123,
+        }
+        event = SnakeseeEvent.from_json(orjson.dumps(payload))
+        assert event.event_type == EventType.JOB_FINISHED
+        assert event.job_id == 7
+        assert event.duration == 58.0

--- a/tests/test_remote_links.py
+++ b/tests/test_remote_links.py
@@ -1,0 +1,91 @@
+"""Tests for AWS console / CloudWatch deep-link builders."""
+
+from snakesee.remote_links import batch_console_url
+from snakesee.remote_links import batch_job_id_from
+from snakesee.remote_links import cloudwatch_url
+from snakesee.remote_links import region_from_arn
+
+ARN = "arn:aws:batch:us-east-1:123456789012:job/12ab34cd-5678-90ef-ghij-klmnopqrstuv"
+BARE_ID = "12ab34cd-5678-90ef-ghij-klmnopqrstuv"
+
+
+class TestBatchJobIdFrom:
+    """Extracting the bare Batch job id from an ARN or id."""
+
+    def test_extracts_from_arn(self) -> None:
+        assert batch_job_id_from(ARN) == BARE_ID
+
+    def test_passes_through_bare_id(self) -> None:
+        assert batch_job_id_from(BARE_ID) == BARE_ID
+
+    def test_none_for_empty(self) -> None:
+        assert batch_job_id_from(None) is None
+        assert batch_job_id_from("") is None
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        # Trailing/leading whitespace must not leak into the id (and thus the URL).
+        assert batch_job_id_from(f"  {ARN}  ") == BARE_ID
+        assert batch_job_id_from(f" {BARE_ID} ") == BARE_ID
+        assert batch_job_id_from("   ") is None
+
+
+class TestRegionFromArn:
+    """Deriving the region from a Batch ARN."""
+
+    def test_region_from_arn(self) -> None:
+        assert region_from_arn(ARN) == "us-east-1"
+
+    def test_none_for_bare_id(self) -> None:
+        assert region_from_arn(BARE_ID) is None
+
+    def test_none_for_none(self) -> None:
+        assert region_from_arn(None) is None
+
+
+class TestBatchConsoleUrl:
+    """Building the AWS Batch job-detail console URL."""
+
+    def test_url_with_explicit_region(self) -> None:
+        url = batch_console_url(BARE_ID, region="eu-west-1")
+        assert url == (
+            "https://eu-west-1.console.aws.amazon.com/batch/home"
+            f"?region=eu-west-1#jobs/detail/{BARE_ID}"
+        )
+
+    def test_region_derived_from_arn(self) -> None:
+        # No explicit region, but the ARN carries it.
+        url = batch_console_url(ARN)
+        assert url is not None
+        assert "region=us-east-1" in url
+        assert f"jobs/detail/{BARE_ID}" in url
+
+    def test_none_when_no_region_available(self) -> None:
+        # Bare id with no region anywhere -> cannot build a console URL.
+        assert batch_console_url(BARE_ID) is None
+
+    def test_none_for_missing_id(self) -> None:
+        assert batch_console_url(None, region="us-east-1") is None
+
+
+class TestCloudwatchUrl:
+    """Building the CloudWatch log-stream URL."""
+
+    def test_url_default_log_group(self) -> None:
+        url = cloudwatch_url("MyJobDef/default/abc123", region="us-east-1")
+        assert url is not None
+        assert url.startswith("https://us-east-1.console.aws.amazon.com/cloudwatch/home")
+        assert "region=us-east-1" in url
+        # The default Batch log group, url-encoded into the CloudWatch fragment.
+        assert "$252Faws$252Fbatch$252Fjob" in url
+
+    def test_slashes_in_stream_are_double_encoded(self) -> None:
+        # Batch stream names contain "/" — each must become "$252F" in the fragment.
+        url = cloudwatch_url("JobDef/default/abc123", region="us-east-1")
+        assert url is not None
+        assert "JobDef$252Fdefault$252Fabc123" in url
+
+    def test_none_without_region(self) -> None:
+        assert cloudwatch_url("stream", region=None) is None
+
+    def test_none_without_stream(self) -> None:
+        assert cloudwatch_url(None, region="us-east-1") is None

--- a/tests/test_remote_queue_wait.py
+++ b/tests/test_remote_queue_wait.py
@@ -1,0 +1,171 @@
+"""Tests for the per-rule / per-queue queue-wait metric (Phase 2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from snakesee.events import EventType
+from snakesee.events import SnakeseeEvent
+from snakesee.state.rule_registry import RuleRegistry
+
+
+def _event(event_type: EventType, **kwargs: object) -> SnakeseeEvent:
+    return SnakeseeEvent(event_type=event_type, timestamp=kwargs.pop("timestamp", 0.0), **kwargs)  # type: ignore[arg-type]
+
+
+class TestQueueWaitTracking:
+    """RuleRegistry tracks queue wait separately from execution duration."""
+
+    def test_record_and_estimate_per_rule(self) -> None:
+        reg = RuleRegistry()
+        reg.record_queue_wait("align", 30.0)
+        reg.record_queue_wait("align", 50.0)
+        reg.record_queue_wait("align", 40.0)
+        # Median of [30, 40, 50] = 40.
+        assert reg.queue_wait_for_rule("align") == 40.0
+
+    def test_unknown_rule_returns_none(self) -> None:
+        reg = RuleRegistry()
+        assert reg.queue_wait_for_rule("nope") is None
+
+    def test_per_queue_tracking(self) -> None:
+        reg = RuleRegistry()
+        reg.record_queue_wait("align", 10.0, queue="on-demand")
+        reg.record_queue_wait("sort", 100.0, queue="spot")
+        reg.record_queue_wait("sort", 200.0, queue="spot")
+        assert reg.queue_wait_for_queue("on-demand") == 10.0
+        assert reg.queue_wait_for_queue("spot") == 150.0
+        assert reg.queue_wait_for_queue("missing") is None
+
+    def test_overall_queue_wait(self) -> None:
+        reg = RuleRegistry()
+        assert reg.overall_queue_wait() is None
+        reg.record_queue_wait("align", 20.0)
+        reg.record_queue_wait("sort", 60.0)
+        # Median across all recorded waits [20, 60] = 40.
+        assert reg.overall_queue_wait() == 40.0
+
+    def test_negative_wait_ignored(self) -> None:
+        # A clock-skew negative wait must not pollute the metric.
+        reg = RuleRegistry()
+        reg.record_queue_wait("align", -5.0)
+        assert reg.queue_wait_for_rule("align") is None
+        assert reg.overall_queue_wait() is None
+
+    def test_queue_wait_does_not_affect_duration_stats(self) -> None:
+        # Recording a queue wait must not touch execution-duration statistics.
+        reg = RuleRegistry()
+        reg.record_completion(rule="align", duration=100.0, timestamp=1.0)
+        reg.record_queue_wait("align", 30.0)
+        stats = reg.get("align")
+        assert stats is not None
+        assert stats.aggregate.durations == [100.0]  # unchanged
+
+
+class TestDataSourceRecordsQueueWait:
+    """A completed remote job feeds queue wait into the rule registry."""
+
+    def test_completed_remote_job_records_queue_wait_and_execution_duration(
+        self, snakemake_dir: object, tmp_path: object
+    ) -> None:
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.data_source import WorkflowDataSource
+
+        assert isinstance(tmp_path, Path)
+        ds = WorkflowDataSource(workflow_dir=tmp_path, use_estimation=True)
+        base = WorkflowProgress(
+            workflow_dir=tmp_path, status=WorkflowStatus.RUNNING, total_jobs=1, completed_jobs=0
+        )
+        # queued at 100, started at 142 (42s wait), stopped at 200 (58s execution).
+        ds.apply_events_to_progress(
+            base,
+            [
+                _event(
+                    EventType.JOB_QUEUED,
+                    timestamp=100.0,
+                    job_id=7,
+                    rule_name="align",
+                    executor="aws-batch",
+                    queue="gv-spot",
+                    queued_at=100.0,
+                )
+            ],
+        )
+        ds.apply_events_to_progress(
+            base, [_event(EventType.JOB_STARTED, timestamp=150.0, job_id=7, started_at=142.0)]
+        )
+        ds.apply_events_to_progress(
+            base,
+            [
+                _event(
+                    EventType.JOB_FINISHED,
+                    timestamp=210.0,
+                    job_id=7,
+                    rule_name="align",
+                    stopped_at=200.0,
+                    duration=58.0,
+                )
+            ],
+        )
+        # _update_rule_stats_from_completions runs in poll_state; call it directly.
+        ds._update_rule_stats_from_completions(base)
+
+        rules = ds._workflow_state.rules
+        # Execution duration learned is the 58s window, NOT 100s wall (dispatch->finish).
+        stats = rules.get("align")
+        assert stats is not None
+        assert stats.aggregate.durations == [58.0]
+        # Queue wait tracked separately, by rule and by queue.
+        assert rules.queue_wait_for_rule("align") == 42.0
+        assert rules.queue_wait_for_queue("gv-spot") == 42.0
+        # Recorded exactly once despite both the event path and the registry-sweep
+        # path running (stats_recorded de-dupes) — a double-record would still read
+        # median 42, so assert the sample count directly.
+        assert rules.queue_wait_count_for_rule("align") == 1
+
+
+class TestQueueFieldPlumbing:
+    """The `queue` field survives enrichment and JobInfo round trips."""
+
+    def test_enrich_remote_fields_backfills_queue(
+        self, snakemake_dir: object, tmp_path: object
+    ) -> None:
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.data_source import WorkflowDataSource
+
+        assert isinstance(tmp_path, Path)
+        ds = WorkflowDataSource(workflow_dir=tmp_path, use_estimation=False)
+        base = WorkflowProgress(
+            workflow_dir=tmp_path, status=WorkflowStatus.RUNNING, total_jobs=1, completed_jobs=0
+        )
+        # A started remote job carries queue in the registry; the running JobInfo
+        # is freshly built without it and must be backfilled by _enrich_remote_fields.
+        result = ds.apply_events_to_progress(
+            base,
+            [
+                _event(
+                    EventType.JOB_STARTED,
+                    timestamp=150.0,
+                    job_id=7,
+                    rule_name="align",
+                    executor="aws-batch",
+                    external_jobid="arn:aws:batch:us-east-1:1:job/abc",
+                    queue="gv-spot",
+                    started_at=142.0,
+                )
+            ],
+        )
+        running = [j for j in result.running_jobs if j.job_id == "7"]
+        assert len(running) == 1
+        assert running[0].queue == "gv-spot"
+
+    def test_job_info_round_trip_preserves_queue(self) -> None:
+        from snakesee.models import JobInfo
+        from snakesee.state.job_registry import Job
+
+        info = JobInfo(rule="align", job_id="7", queue="gv-spot", external_jobid="abc")
+        job = Job.from_job_info(info)
+        assert job.queue == "gv-spot"
+        assert job.to_job_info().queue == "gv-spot"

--- a/tests/test_remote_queued.py
+++ b/tests/test_remote_queued.py
@@ -1,0 +1,282 @@
+"""Tests for the QUEUED state and remote-field enrichment (Phase 1)."""
+
+from __future__ import annotations
+
+from snakesee.events import EventType
+from snakesee.events import SnakeseeEvent
+from snakesee.state.job_registry import JobRegistry
+from snakesee.state.job_registry import JobStatus
+
+ARN = "arn:aws:batch:us-east-1:1:job/abc"
+
+
+def _event(event_type: EventType, **kwargs: object) -> SnakeseeEvent:
+    return SnakeseeEvent(event_type=event_type, timestamp=kwargs.pop("timestamp", 0.0), **kwargs)  # type: ignore[arg-type]
+
+
+class TestQueuedTransitions:
+    """A remote job moves pending -> queued -> running -> completed via events."""
+
+    def test_job_queued_event_sets_queued_status(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(
+            _event(
+                EventType.JOB_QUEUED,
+                timestamp=100.0,
+                job_id=7,
+                rule_name="align",
+                executor="aws-batch",
+                external_jobid=ARN,
+                queued_at=100.0,
+            )
+        )
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.status is JobStatus.QUEUED
+        assert job.queued_at == 100.0
+        assert job.external_jobid == ARN
+        assert job.executor == "aws-batch"
+        assert reg.queued() == [job]
+
+    def test_queued_then_started_moves_out_of_queued(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(_event(EventType.JOB_QUEUED, timestamp=100.0, job_id=7, rule_name="align"))
+        reg.apply_event(_event(EventType.JOB_STARTED, timestamp=150.0, job_id=7, started_at=142.0))
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.status is JobStatus.RUNNING
+        # start_time is the executor's true start, not the event emission time.
+        assert job.start_time == 142.0
+        assert reg.queued() == []
+        assert reg.running() == [job]
+
+    def test_queue_wait_computed(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(_event(EventType.JOB_QUEUED, timestamp=100.0, job_id=7, queued_at=100.0))
+        reg.apply_event(_event(EventType.JOB_STARTED, timestamp=160.0, job_id=7, started_at=142.0))
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.queue_wait == 42.0  # 142 - 100
+
+    def test_finished_uses_stopped_at_for_execution_window(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(_event(EventType.JOB_QUEUED, timestamp=100.0, job_id=7, queued_at=100.0))
+        reg.apply_event(_event(EventType.JOB_STARTED, timestamp=150.0, job_id=7, started_at=142.0))
+        reg.apply_event(_event(EventType.JOB_FINISHED, timestamp=210.0, job_id=7, stopped_at=200.0))
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.status is JobStatus.COMPLETED
+        assert job.end_time == 200.0
+        # duration is the execution window (200 - 142), excluding the 42s queue wait.
+        assert job.duration == 58.0
+
+
+class TestRemoteFieldEnrichment:
+    """apply_event carries remote fields onto an existing job across events."""
+
+    def test_started_event_populates_remote_fields(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(
+            _event(
+                EventType.JOB_STARTED,
+                timestamp=150.0,
+                job_id=7,
+                rule_name="align",
+                executor="aws-batch",
+                external_jobid=ARN,
+                region="us-east-1",
+                log_stream="JobDef/default/abc",
+                started_at=142.0,
+            )
+        )
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.external_jobid == ARN
+        assert job.executor == "aws-batch"
+        assert job.region == "us-east-1"
+        assert job.log_stream == "JobDef/default/abc"
+        # to_job_info round-trips the remote fields.
+        info = job.to_job_info()
+        assert info.external_jobid == ARN
+        assert info.region == "us-east-1"
+
+    def test_unknown_event_type_still_ignored(self) -> None:
+        reg = JobRegistry()
+        assert reg.apply_event(_event(EventType.PROGRESS, timestamp=1.0)) is None
+
+
+class TestOutOfOrderEvents:
+    """Stale/out-of-order remote events must not corrupt the state machine."""
+
+    def test_late_queued_does_not_demote_running(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(_event(EventType.JOB_STARTED, timestamp=150.0, job_id=7, started_at=142.0))
+        # A stale JOB_QUEUED arrives after the job already started.
+        reg.apply_event(_event(EventType.JOB_QUEUED, timestamp=100.0, job_id=7, queued_at=100.0))
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.status is JobStatus.RUNNING  # not demoted
+        assert reg.queued() == []
+
+    def test_late_queued_does_not_resurrect_completed(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(_event(EventType.JOB_STARTED, timestamp=150.0, job_id=7, started_at=142.0))
+        reg.apply_event(_event(EventType.JOB_FINISHED, timestamp=210.0, job_id=7, stopped_at=200.0))
+        reg.apply_event(_event(EventType.JOB_QUEUED, timestamp=100.0, job_id=7))
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.status is JobStatus.COMPLETED  # not resurrected
+
+    def test_finished_without_started_has_no_duration(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(_event(EventType.JOB_FINISHED, timestamp=210.0, job_id=7, stopped_at=200.0))
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.status is JobStatus.COMPLETED
+        assert job.start_time is None
+        assert job.duration is None
+        assert job.queue_wait is None  # no start_time
+
+    def test_local_started_without_started_at_uses_event_timestamp(self) -> None:
+        # Regression: a plain (non-remote) JOB_STARTED has no started_at.
+        reg = JobRegistry()
+        reg.apply_event(_event(EventType.JOB_STARTED, timestamp=150.0, job_id=7, rule_name="align"))
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.start_time == 150.0  # falls back to event timestamp
+
+
+class TestDataSourceQueuedRouting:
+    """apply_events_to_progress routes queued jobs to queued_jobs_list, not running."""
+
+    def test_queued_job_not_in_running(self, snakemake_dir: object, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.data_source import WorkflowDataSource
+
+        assert isinstance(tmp_path, Path)
+        ds = WorkflowDataSource(workflow_dir=tmp_path, use_estimation=False)
+        base = WorkflowProgress(
+            workflow_dir=tmp_path, status=WorkflowStatus.RUNNING, total_jobs=2, completed_jobs=0
+        )
+        events = [
+            _event(
+                EventType.JOB_QUEUED,
+                timestamp=100.0,
+                job_id=7,
+                rule_name="align",
+                executor="aws-batch",
+                external_jobid=ARN,
+                queued_at=100.0,
+            ),
+        ]
+        result = ds.apply_events_to_progress(base, events)
+        assert [j.job_id for j in result.queued_jobs_list] == ["7"]
+        assert all(j.job_id != "7" for j in result.running_jobs)
+        # The queued JobInfo carries the external id for display.
+        assert result.queued_jobs_list[0].external_jobid == ARN
+
+    def test_queued_then_started_appears_running_not_queued(
+        self, snakemake_dir: object, tmp_path: object
+    ) -> None:
+        from pathlib import Path
+
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.data_source import WorkflowDataSource
+
+        assert isinstance(tmp_path, Path)
+        ds = WorkflowDataSource(workflow_dir=tmp_path, use_estimation=False)
+        base = WorkflowProgress(
+            workflow_dir=tmp_path, status=WorkflowStatus.RUNNING, total_jobs=1, completed_jobs=0
+        )
+        ds.apply_events_to_progress(
+            base, [_event(EventType.JOB_QUEUED, timestamp=100.0, job_id=7, rule_name="align")]
+        )
+        result = ds.apply_events_to_progress(
+            base, [_event(EventType.JOB_STARTED, timestamp=150.0, job_id=7, started_at=142.0)]
+        )
+        assert result.queued_jobs_list == []
+        assert [j.job_id for j in result.running_jobs] == ["7"]
+
+    def test_running_jobinfo_uses_true_started_at(
+        self, snakemake_dir: object, tmp_path: object
+    ) -> None:
+        # The running JobInfo's start_time must be the executor's started_at, not
+        # the event emission time, so elapsed/duration exclude queue wait.
+        from pathlib import Path
+
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.data_source import WorkflowDataSource
+
+        assert isinstance(tmp_path, Path)
+        ds = WorkflowDataSource(workflow_dir=tmp_path, use_estimation=False)
+        base = WorkflowProgress(
+            workflow_dir=tmp_path, status=WorkflowStatus.RUNNING, total_jobs=1, completed_jobs=0
+        )
+        result = ds.apply_events_to_progress(
+            base,
+            [
+                _event(
+                    EventType.JOB_STARTED,
+                    timestamp=150.0,
+                    job_id=7,
+                    rule_name="align",
+                    started_at=142.0,
+                )
+            ],
+        )
+        running = [j for j in result.running_jobs if j.job_id == "7"]
+        assert len(running) == 1
+        assert running[0].start_time == 142.0
+
+
+class TestHeaderQueuedCount:
+    """The header surfaces the queued count when remote jobs are queued."""
+
+    def test_header_shows_queued_count(self) -> None:
+        from io import StringIO
+        from pathlib import Path
+
+        from rich.console import Console
+
+        from snakesee.models import JobInfo
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.renderables import make_header
+
+        progress = WorkflowProgress(
+            workflow_dir=Path("/wf"),
+            status=WorkflowStatus.RUNNING,
+            total_jobs=3,
+            completed_jobs=0,
+            queued_jobs_list=[JobInfo(rule="align", job_id="7")],
+        )
+        panel = make_header(progress, "/wf", paused=False, event_reader=None)
+        buf = StringIO()
+        Console(file=buf, width=200).print(panel)
+        assert "Queued: 1" in buf.getvalue()
+
+    def test_header_omits_queued_when_none(self) -> None:
+        from io import StringIO
+        from pathlib import Path
+
+        from rich.console import Console
+
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.renderables import make_header
+
+        progress = WorkflowProgress(
+            workflow_dir=Path("/wf"),
+            status=WorkflowStatus.RUNNING,
+            total_jobs=3,
+            completed_jobs=0,
+        )
+        panel = make_header(progress, "/wf", paused=False, event_reader=None)
+        buf = StringIO()
+        Console(file=buf, width=200).print(panel)
+        assert "Queued" not in buf.getvalue()

--- a/tests/test_remote_surface.py
+++ b/tests/test_remote_surface.py
@@ -51,6 +51,21 @@ class TestMakeRemoteJobInfo:
         job = JobInfo(rule="align", job_id="1", external_jobid="abc123")
         assert make_remote_job_info(job)[0] == "remote job: abc123"
 
+    def test_shows_queue_and_queue_wait(self) -> None:
+        """Queue name and queue wait (start_time - queued_at) are surfaced."""
+        job = JobInfo(
+            rule="align",
+            job_id="1",
+            external_jobid="abc123",
+            executor="aws-batch",
+            queue="graviton-spot",
+            queued_at=100.0,
+            start_time=142.0,  # 42s queue wait
+        )
+        lines = make_remote_job_info(job)
+        assert any("queue:" in line and "graviton-spot" in line for line in lines)
+        assert any("queued for:" in line for line in lines)
+
 
 class TestIncompleteJobCarriesExternalId:
     """The incomplete->JobInfo wiring preserves external_jobid (parser.core)."""

--- a/tests/test_remote_surface.py
+++ b/tests/test_remote_surface.py
@@ -1,0 +1,78 @@
+"""Tests for surfacing remote job info in the TUI (Phase 0 degradation floor)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from snakesee.models import JobInfo
+from snakesee.persistence.backend import IncompleteJob
+from snakesee.tui.renderables import make_remote_job_info
+
+ARN = "arn:aws:batch:us-east-1:123456789012:job/abc123"
+
+
+class TestMakeRemoteJobInfo:
+    """make_remote_job_info turns a JobInfo into display lines."""
+
+    def test_local_job_has_no_remote_lines(self) -> None:
+        """A job with no external id produces no lines at all."""
+        job = JobInfo(rule="align", job_id="1")
+        assert make_remote_job_info(job) == []
+
+    def test_bare_id_shows_id_only(self) -> None:
+        """A bare external id with no region shows the id but no console link."""
+        job = JobInfo(rule="align", job_id="1", external_jobid="abc123", executor="aws-batch")
+        lines = make_remote_job_info(job)
+        assert lines == ["aws-batch job: abc123"]
+
+    def test_arn_yields_console_link(self) -> None:
+        """An ARN carries its region, so a console link can be built."""
+        job = JobInfo(rule="align", job_id="1", external_jobid=ARN, executor="aws-batch")
+        lines = make_remote_job_info(job)
+        assert lines[0] == f"aws-batch job: {ARN}"
+        assert any("console:" in line and "region=us-east-1" in line for line in lines)
+
+    def test_region_and_log_stream_yield_both_links(self) -> None:
+        """With region + log stream, both console and CloudWatch links appear."""
+        job = JobInfo(
+            rule="align",
+            job_id="1",
+            external_jobid="abc123",
+            executor="aws-batch",
+            region="eu-west-1",
+            log_stream="JobDef/default/abc",
+        )
+        lines = make_remote_job_info(job)
+        assert any("console:" in line for line in lines)
+        assert any("logs:" in line and "cloudwatch" in line for line in lines)
+
+    def test_falls_back_to_remote_label_without_executor(self) -> None:
+        """When the executor name is unknown, a neutral 'remote' label is used."""
+        job = JobInfo(rule="align", job_id="1", external_jobid="abc123")
+        assert make_remote_job_info(job)[0] == "remote job: abc123"
+
+
+class TestIncompleteJobCarriesExternalId:
+    """The incomplete->JobInfo wiring preserves external_jobid (parser.core)."""
+
+    def test_external_jobid_preserved(self) -> None:
+        """Building a running JobInfo from an IncompleteJob keeps the external id.
+
+        This mirrors the construction in parser.core.parse_workflow_state without
+        needing a populated .snakemake DB.
+        """
+        incomplete = IncompleteJob(
+            start_time=100.0,
+            output_file=Path("results/sample.bam"),
+            rule="align",
+            external_jobid=ARN,
+        )
+        job = JobInfo(
+            rule=incomplete.rule or "unknown",
+            start_time=incomplete.start_time,
+            output_file=incomplete.output_file,
+            external_jobid=incomplete.external_jobid,
+        )
+        assert job.external_jobid == ARN
+        # And it round-trips into display lines.
+        assert make_remote_job_info(job)[0].endswith(ARN)


### PR DESCRIPTION
First-class monitoring of jobs run on a remote executor (AWS Batch), read passively from the event stream.

- Versioned remote-job-state event contract + logger-plugin adapter; new `JOB_QUEUED` event; forward-compatible event parsing.
- Surface the external job id with AWS console / CloudWatch deep links.
- Real QUEUED vs RUNNING distinction; execution-window timing from the executor's true start/stop.
- Queue wait tracked as its own per-rule/per-queue metric.

snakesee stays a passive reader — remote state is pushed in by the executor + logger plugin. Tested against synthetic events (no live AWS).

First of 3 stacked PRs: core → observability → cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote job queue tracking with per-rule/queue median queue-wait metrics.
  * AWS Batch and CloudWatch deep links for remote jobs.
  * Remote job metadata surfaced in the terminal UI and in job-log headers.
  * Support for a JOB_QUEUED event and handler support for remote-executor payloads.

* **Bug Fixes**
  * Forward-compatible JSON parsing ignores unknown event fields.
  * Events are immutable to prevent accidental mutation.

* **Tests**
  * Expanded test coverage for remote payloads, queue-wait, queued state, links, and UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->