### PR TITLE
feat: remote observability + termination classification

### DIFF
--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/events.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/events.py
@@ -78,6 +78,9 @@ class SnakeseeEvent:
     queue: str | None = None
     log_stream: str | None = None
     region: str | None = None
+    termination_category: str | None = None
+    termination_source: str | None = None
+    termination_confidence: str | None = None
 
     def to_json(self) -> str:
         """Serialize to compact JSON string.

--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/events.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/events.py
@@ -49,6 +49,9 @@ class SnakeseeEvent:
         queue: The remote queue the job was routed to, if known.
         log_stream: Backend log stream identifier (e.g. CloudWatch stream).
         region: Cloud region, used to build console deep links.
+        termination_category: Why the job died (e.g. "spot", "oom"), if classified.
+        termination_source: Provenance of the classification (e.g. "aws_instance_state").
+        termination_confidence: How sure the producer was ("high" / "low").
     """
 
     event_type: EventType

--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/handler.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/handler.py
@@ -8,7 +8,7 @@ from typing import Any
 from snakemake_interface_logger_plugins.base import LogHandlerBase
 
 from snakemake_logger_plugin_snakesee.events import EventType, SnakeseeEvent
-from snakemake_logger_plugin_snakesee.remote_adapter import WIRE_KEY, event_from_payload
+from snakemake_logger_plugin_snakesee.remote_adapter import event_from_payload, payload_from_record
 from snakemake_logger_plugin_snakesee.settings import LogHandlerSettings
 from snakemake_logger_plugin_snakesee.writer import EventWriter
 
@@ -105,11 +105,10 @@ class LogHandler(LogHandlerBase):
         timestamp = time.time()
 
         # Remote executors attach a structured remote-job-state payload to an
-        # ordinary log record (under ``snakesee_remote``) instead of using a
-        # Snakemake LogEvent — the LogEvent enum is fixed upstream and an
-        # executor cannot extend it. Handle that channel first; such records may
-        # have no ``event`` attribute at all.
-        remote_payload = getattr(record, WIRE_KEY, None)
+        # ordinary log record instead of using a Snakemake LogEvent — the
+        # LogEvent enum is fixed upstream and an executor cannot extend it. Handle
+        # that channel first; such records may have no ``event`` attribute at all.
+        remote_payload = payload_from_record(record)
         if remote_payload is not None:
             remote_event = event_from_payload(remote_payload, timestamp)
             if remote_event is not None:

--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/handler.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/handler.py
@@ -19,7 +19,7 @@ except ImportError:
     # Fallback for older versions
     from enum import Enum
 
-    class LogEvent(str, Enum):
+    class LogEvent(str, Enum):  # type: ignore[no-redef]
         """Fallback LogEvent enum for compatibility."""
 
         ERROR = "error"
@@ -53,9 +53,11 @@ class LogHandler(LogHandlerBase):
         elif not isinstance(workflow_dir, Path):
             workflow_dir = Path(workflow_dir)
 
-        # Get settings with defaults if None
+        # Get settings with defaults. self.settings is typed as the base
+        # LogHandlerSettingsBase (or None); narrow to this plugin's concrete
+        # LogHandlerSettings so its event_file/buffer_size fields resolve.
         settings = self.settings
-        if settings is None:
+        if not isinstance(settings, LogHandlerSettings):
             settings = LogHandlerSettings()
 
         event_path = workflow_dir / settings.event_file

--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/remote_adapter.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/remote_adapter.py
@@ -123,6 +123,9 @@ def event_from_payload(payload: Any, timestamp: float) -> SnakeseeEvent | None:
         queue=_opt_str(payload.get("queue")),
         log_stream=_opt_str(payload.get("log_stream")),
         region=_opt_str(payload.get("region")),
+        termination_category=_opt_str(payload.get("termination_category")),
+        termination_source=_opt_str(payload.get("termination_source")),
+        termination_confidence=_opt_str(payload.get("termination_confidence")),
         duration=duration,
         # Surface the failure reason as the error message for JOB_ERROR events.
         error_message=status_reason if event_type == EventType.JOB_ERROR else None,

--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/remote_adapter.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/remote_adapter.py
@@ -21,10 +21,24 @@ from typing import Any, Final
 from snakemake_logger_plugin_snakesee.events import EventType, SnakeseeEvent
 
 # Log-record attribute the executor uses to carry the payload.
+#
+# Two keys are recognised so the consumer is forward-compatible without any
+# change to the rest of the plugin or to snakesee:
+#   - WIRE_KEY ("snakesee_remote", schema_version 1) is the snakesee-specific
+#     contract the AWS Batch executor emits today.
+#   - NEUTRAL_WIRE_KEY ("remote_job_state", schema_version 2) is the
+#     backend-neutral shape proposed for upstream standardisation (Tier D). When
+#     Snakemake's executor interface emits a standard remote-job-state record,
+#     it will use this key; the payload shape is otherwise identical, so only
+#     this adapter needs to know about it.
 WIRE_KEY: Final[str] = "snakesee_remote"
+NEUTRAL_WIRE_KEY: Final[str] = "remote_job_state"
+
+# All record attributes that may carry a remote-state payload, newest first.
+WIRE_KEYS: Final[tuple[str, ...]] = (NEUTRAL_WIRE_KEY, WIRE_KEY)
 
 # Wire schema versions this plugin understands.
-SUPPORTED_SCHEMA_VERSIONS: Final[frozenset[int]] = frozenset({1})
+SUPPORTED_SCHEMA_VERSIONS: Final[frozenset[int]] = frozenset({1, 2})
 
 # Normalized phase string -> snakesee event type.
 _PHASE_TO_EVENT: Final[dict[str, EventType]] = {
@@ -33,6 +47,20 @@ _PHASE_TO_EVENT: Final[dict[str, EventType]] = {
     "succeeded": EventType.JOB_FINISHED,
     "failed": EventType.JOB_ERROR,
 }
+
+
+def payload_from_record(record: Any) -> Any | None:
+    """Extract a remote-state payload from a log record, or None if absent.
+
+    Checks the recognised wire keys (neutral first, then the snakesee-specific
+    one) so a record carrying either contract is handled. This is the single
+    place that knows *where* on the record the payload lives.
+    """
+    for key in WIRE_KEYS:
+        payload = getattr(record, key, None)
+        if payload is not None:
+            return payload
+    return None
 
 
 def event_from_payload(payload: Any, timestamp: float) -> SnakeseeEvent | None:

--- a/snakemake-logger-plugin-snakesee/tests/test_remote_adapter.py
+++ b/snakemake-logger-plugin-snakesee/tests/test_remote_adapter.py
@@ -4,7 +4,12 @@ import logging
 from typing import Any
 
 from snakemake_logger_plugin_snakesee.events import EventType
-from snakemake_logger_plugin_snakesee.remote_adapter import WIRE_KEY, event_from_payload
+from snakemake_logger_plugin_snakesee.remote_adapter import (
+    NEUTRAL_WIRE_KEY,
+    WIRE_KEY,
+    event_from_payload,
+    payload_from_record,
+)
 
 
 def _payload(**overrides: Any) -> dict[str, Any]:
@@ -67,8 +72,32 @@ class TestEventFromPayload:
         assert event.region == "us-east-1"
         assert event.queue == "gv-spot"
 
+    def test_accepts_neutral_v2_schema(self) -> None:
+        # The backend-neutral Tier-D shape (schema_version 2) has identical fields
+        # and must translate to the same event as v1.
+        event = event_from_payload(_payload(schema_version=2, phase="running"), timestamp=1.0)
+        assert event is not None
+        assert event.event_type == EventType.JOB_STARTED
+
+    def test_v1_and_v2_produce_equal_events(self) -> None:
+        # The core Tier-D guarantee: same fields under v1 vs v2 yield identical
+        # events (only the schema_version gate differs). Locks out any future
+        # version-keyed divergence in event_from_payload.
+        fields = dict(
+            phase="succeeded",
+            external_jobid="arn:aws:batch:us-east-1:1:job/abc",
+            started_at=142.0,
+            stopped_at=200.0,
+            exit_code=0,
+            queue="gv-spot",
+            region="us-east-1",
+        )
+        v1 = event_from_payload(_payload(schema_version=1, **fields), timestamp=5.0)
+        v2 = event_from_payload(_payload(schema_version=2, **fields), timestamp=5.0)
+        assert v1 == v2
+
     def test_unsupported_version_returns_none(self) -> None:
-        assert event_from_payload(_payload(schema_version=2), timestamp=1.0) is None
+        assert event_from_payload(_payload(schema_version=3), timestamp=1.0) is None
 
     def test_unknown_phase_returns_none(self) -> None:
         assert event_from_payload(_payload(phase="bogus"), timestamp=1.0) is None
@@ -84,6 +113,27 @@ class _FakeRecord:
     def __init__(self, **attrs: Any) -> None:
         for key, value in attrs.items():
             setattr(self, key, value)
+
+
+class TestPayloadFromRecord:
+    """payload_from_record finds the payload under either wire key."""
+
+    def test_finds_legacy_key(self) -> None:
+        rec = _FakeRecord(**{WIRE_KEY: _payload()})
+        assert payload_from_record(rec) is not None
+
+    def test_finds_neutral_key(self) -> None:
+        rec = _FakeRecord(**{NEUTRAL_WIRE_KEY: _payload(schema_version=2)})
+        assert payload_from_record(rec) is not None
+
+    def test_prefers_neutral_over_legacy(self) -> None:
+        neutral = _payload(schema_version=2, jobid=2)
+        legacy = _payload(schema_version=1, jobid=1)
+        rec = _FakeRecord(**{NEUTRAL_WIRE_KEY: neutral, WIRE_KEY: legacy})
+        assert payload_from_record(rec) is neutral
+
+    def test_none_when_absent(self) -> None:
+        assert payload_from_record(_FakeRecord(event=None)) is None
 
 
 class TestHandlerEmitHook:
@@ -107,6 +157,14 @@ class TestHandlerEmitHook:
     def test_remote_record_emits_event(self, tmp_path: Any) -> None:
         handler = self._make_handler(tmp_path)
         record = _FakeRecord(**{WIRE_KEY: _payload(phase="running")})
+        handler.emit(record)
+        assert len(handler._writer.events) == 1
+        assert handler._writer.events[0].event_type == EventType.JOB_STARTED
+
+    def test_neutral_v2_record_emits_event(self, tmp_path: Any) -> None:
+        # A record carrying the neutral Tier-D key is handled with no other change.
+        handler = self._make_handler(tmp_path)
+        record = _FakeRecord(**{NEUTRAL_WIRE_KEY: _payload(schema_version=2, phase="running")})
         handler.emit(record)
         assert len(handler._writer.events) == 1
         assert handler._writer.events[0].event_type == EventType.JOB_STARTED

--- a/snakemake-logger-plugin-snakesee/tests/test_remote_adapter.py
+++ b/snakemake-logger-plugin-snakesee/tests/test_remote_adapter.py
@@ -62,6 +62,21 @@ class TestEventFromPayload:
         assert event.status_reason == "OOM killed"
         assert event.exit_code == 137
 
+    def test_termination_fields_carried(self) -> None:
+        event = event_from_payload(
+            _payload(
+                phase="failed",
+                termination_category="spot",
+                termination_source="aws_instance_state",
+                termination_confidence="high",
+            ),
+            timestamp=1.0,
+        )
+        assert event is not None
+        assert event.termination_category == "spot"
+        assert event.termination_source == "aws_instance_state"
+        assert event.termination_confidence == "high"
+
     def test_external_id_and_region_carried(self) -> None:
         event = event_from_payload(
             _payload(external_jobid="arn:...:job/abc", region="us-east-1", queue="gv-spot"),

--- a/snakesee/events.py
+++ b/snakesee/events.py
@@ -69,6 +69,9 @@ class SnakeseeEvent:
         queue: The remote queue the job was routed to, if known.
         log_stream: Backend log stream identifier (e.g. CloudWatch stream).
         region: Cloud region, used to build console deep links.
+        termination_category: Why the job died (e.g. "spot", "oom"), if classified.
+        termination_source: Provenance of the classification (e.g. "aws_instance_state").
+        termination_confidence: How sure the producer was ("high" / "low").
     """
 
     event_type: EventType
@@ -98,6 +101,9 @@ class SnakeseeEvent:
     queue: str | None = None
     log_stream: str | None = None
     region: str | None = None
+    termination_category: str | None = None
+    termination_source: str | None = None
+    termination_confidence: str | None = None
 
     @classmethod
     def from_json(cls, json_str: str | bytes) -> "SnakeseeEvent":

--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -55,6 +55,9 @@ class JobInfo:
             remote job, start_time is the true execution start, so the difference
             is the queue wait.
         queue: The remote queue / compute environment the job was routed to, if known.
+        attempt: Attempt number for a retried/preempted remote job, if known.
+        exit_code: Container/process exit code for a finished remote job, if known.
+        status_reason: Backend-provided reason string (e.g. failure cause), if any.
     """
 
     rule: str
@@ -72,6 +75,9 @@ class JobInfo:
     log_stream: str | None = None
     queued_at: float | None = None
     queue: str | None = None
+    attempt: int | None = None
+    exit_code: int | None = None
+    status_reason: str | None = None
 
     @property
     def queue_wait(self) -> float | None:

--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -58,6 +58,9 @@ class JobInfo:
         attempt: Attempt number for a retried/preempted remote job, if known.
         exit_code: Container/process exit code for a finished remote job, if known.
         status_reason: Backend-provided reason string (e.g. failure cause), if any.
+        termination_category: Why the job died (e.g. "spot", "oom"), if classified.
+        termination_source: Provenance of the classification (e.g. "aws_instance_state").
+        termination_confidence: How sure the producer was ("high" / "low").
     """
 
     rule: str
@@ -78,6 +81,9 @@ class JobInfo:
     attempt: int | None = None
     exit_code: int | None = None
     status_reason: str | None = None
+    termination_category: str | None = None
+    termination_source: str | None = None
+    termination_confidence: str | None = None
 
     @property
     def queue_wait(self) -> float | None:

--- a/snakesee/remote_links.py
+++ b/snakesee/remote_links.py
@@ -114,3 +114,32 @@ def _cw_encode(value: str) -> str:
     """Apply CloudWatch's double percent-encoding to a path component."""
     once = quote(value, safe="")
     return once.replace("%", "$25")
+
+
+# Substrings AWS Batch / ECS use in statusReason when a Spot instance is reclaimed.
+_SPOT_MARKERS = ("spot interruption", "spot instance", "ec2 spot")
+# A reclaimed Spot host shows up as the EC2 instance being terminated out from under
+# the job; pair the host-terminated phrasing with a spot hint to avoid false positives.
+_HOST_TERMINATED = "host ec2"
+
+
+def is_spot_interruption(status_reason: str | None) -> bool:
+    """Heuristically detect whether a failure was a Spot-instance interruption.
+
+    Args:
+        status_reason: The backend-provided status reason string, if any.
+
+    Returns:
+        True if the reason looks like a Spot reclamation / interruption.
+    """
+    if not status_reason:
+        return False
+    lowered = status_reason.lower()
+    if any(marker in lowered for marker in _SPOT_MARKERS):
+        return True
+    # "Host EC2 (instance i-...) terminated." with a spot hint nearby. Note this
+    # conservatively misses real Spot reclamations where Batch phrases the host
+    # termination without the word "spot" — we accept that false negative to avoid
+    # misclassifying ordinary host failures. A structured signal from the executor
+    # would supersede this heuristic.
+    return _HOST_TERMINATED in lowered and "spot" in lowered

--- a/snakesee/remote_termination.py
+++ b/snakesee/remote_termination.py
@@ -1,0 +1,74 @@
+"""Normalized job-termination classification: value set and rendering.
+
+When a remote job dies, *why* it died (Spot reclamation, OOM, timeout, node
+failure, ...) is a fact the backend knows with varying certainty. snakesee does
+not classify terminations itself — that happens upstream (the executor, which
+has the cloud context) and arrives on the event as a structured triple:
+
+    termination_category   — what kind of death (this module's TERM_* values)
+    termination_source     — where the classification came from (provenance)
+    termination_confidence — how sure the producer was (high / low)
+
+snakesee's only job is to *render* that classification honestly: a high-confidence
+classification is stated firmly, a low-confidence (heuristic) one is phrased
+tentatively, so the UI never asserts something a lower layer merely guessed.
+
+This module is the reader-side half of the contract; the executor defines the
+same value strings independently (the two packages can't share code).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Termination categories (wire strings).
+TERM_SPOT: Final[str] = "spot"
+TERM_OOM: Final[str] = "oom"
+TERM_TIMEOUT: Final[str] = "timeout"
+TERM_NODE_FAILURE: Final[str] = "node_failure"
+TERM_CANCELLED: Final[str] = "cancelled"
+TERM_DEPENDENCY: Final[str] = "dependency"
+TERM_IMAGE_PULL: Final[str] = "image_pull"
+TERM_UNKNOWN: Final[str] = "unknown"
+
+# Confidence levels (wire strings).
+CONFIDENCE_HIGH: Final[str] = "high"
+CONFIDENCE_LOW: Final[str] = "low"
+
+# Classification provenance (wire strings) — most to least authoritative.
+SOURCE_EVENTBRIDGE: Final[str] = "eventbridge"
+SOURCE_AWS_INSTANCE_STATE: Final[str] = "aws_instance_state"
+SOURCE_EXECUTOR_HEURISTIC: Final[str] = "executor_heuristic"
+SOURCE_STATUS_REASON: Final[str] = "status_reason"
+
+# Friendly labels for known categories. Unknown categories fall back to the raw
+# string so a newer executor's category still renders (forward compatibility).
+_CATEGORY_LABELS: Final[dict[str, str]] = {
+    TERM_SPOT: "spot interrupted",
+    TERM_OOM: "out of memory",
+    TERM_TIMEOUT: "timed out",
+    TERM_NODE_FAILURE: "node failure",
+    TERM_CANCELLED: "cancelled",
+    TERM_DEPENDENCY: "dependency failed",
+    TERM_IMAGE_PULL: "image pull failed",
+}
+
+
+def format_termination_marker(category: str | None, confidence: str | None) -> str | None:
+    """Render a one-line termination marker, phrased by confidence.
+
+    Args:
+        category: The termination category (a TERM_* value, or a forward-compat
+            string). None or TERM_UNKNOWN yields no marker.
+        confidence: CONFIDENCE_HIGH renders a firm marker; anything else
+            (including None) renders a tentative one.
+
+    Returns:
+        A marker string, or None when there is nothing meaningful to assert.
+    """
+    if not category or category == TERM_UNKNOWN:
+        return None
+    label = _CATEGORY_LABELS.get(category, category.replace("_", " "))
+    if confidence == CONFIDENCE_HIGH:
+        return f"⚠ {label}"
+    return f"possibly {label}"

--- a/snakesee/state/job_registry.py
+++ b/snakesee/state/job_registry.py
@@ -57,6 +57,9 @@ class Job:
         attempt: Attempt number for a retried/preempted remote job, if known.
         exit_code: Container/process exit code for a finished remote job, if known.
         status_reason: Backend-provided reason string (e.g. failure cause), if any.
+        termination_category: Why the job died (e.g. "spot", "oom"), if classified.
+        termination_source: Provenance of the classification (e.g. "aws_instance_state").
+        termination_confidence: How sure the producer was ("high" / "low").
     """
 
     key: str
@@ -78,6 +81,9 @@ class Job:
     attempt: int | None = None
     exit_code: int | None = None
     status_reason: str | None = None
+    termination_category: str | None = None
+    termination_source: str | None = None
+    termination_confidence: str | None = None
     stats_recorded: bool = False
 
     @property
@@ -133,6 +139,9 @@ class Job:
             attempt=self.attempt,
             exit_code=self.exit_code,
             status_reason=self.status_reason,
+            termination_category=self.termination_category,
+            termination_source=self.termination_source,
+            termination_confidence=self.termination_confidence,
         )
 
     @classmethod
@@ -172,6 +181,9 @@ class Job:
             attempt=job_info.attempt,
             exit_code=job_info.exit_code,
             status_reason=job_info.status_reason,
+            termination_category=job_info.termination_category,
+            termination_source=job_info.termination_source,
+            termination_confidence=job_info.termination_confidence,
         )
 
 
@@ -515,6 +527,12 @@ class JobRegistry:
             job.exit_code = event.exit_code
         if event.status_reason is not None:
             job.status_reason = event.status_reason
+        if event.termination_category is not None:
+            job.termination_category = event.termination_category
+        if event.termination_source is not None:
+            job.termination_source = event.termination_source
+        if event.termination_confidence is not None:
+            job.termination_confidence = event.termination_confidence
         if event.queued_at is not None and job.queued_at is None:
             job.queued_at = event.queued_at
 

--- a/snakesee/state/job_registry.py
+++ b/snakesee/state/job_registry.py
@@ -54,6 +54,9 @@ class Job:
         log_stream: Backend log stream identifier (e.g. CloudWatch stream), if known.
         queued_at: Epoch seconds the job entered the remote queue, if known.
         queue: The remote queue / compute environment the job was routed to, if known.
+        attempt: Attempt number for a retried/preempted remote job, if known.
+        exit_code: Container/process exit code for a finished remote job, if known.
+        status_reason: Backend-provided reason string (e.g. failure cause), if any.
     """
 
     key: str
@@ -72,6 +75,9 @@ class Job:
     log_stream: str | None = None
     queued_at: float | None = None
     queue: str | None = None
+    attempt: int | None = None
+    exit_code: int | None = None
+    status_reason: str | None = None
     stats_recorded: bool = False
 
     @property
@@ -124,6 +130,9 @@ class Job:
             log_stream=self.log_stream,
             queued_at=self.queued_at,
             queue=self.queue,
+            attempt=self.attempt,
+            exit_code=self.exit_code,
+            status_reason=self.status_reason,
         )
 
     @classmethod
@@ -160,6 +169,9 @@ class Job:
             log_stream=job_info.log_stream,
             queued_at=job_info.queued_at,
             queue=job_info.queue,
+            attempt=job_info.attempt,
+            exit_code=job_info.exit_code,
+            status_reason=job_info.status_reason,
         )
 
 
@@ -497,6 +509,12 @@ class JobRegistry:
             job.log_stream = event.log_stream
         if event.queue is not None:
             job.queue = event.queue
+        if event.attempt is not None:
+            job.attempt = event.attempt
+        if event.exit_code is not None:
+            job.exit_code = event.exit_code
+        if event.status_reason is not None:
+            job.status_reason = event.status_reason
         if event.queued_at is not None and job.queued_at is None:
             job.queued_at = event.queued_at
 

--- a/snakesee/tui/data_source.py
+++ b/snakesee/tui/data_source.py
@@ -1076,6 +1076,11 @@ class WorkflowDataSource:
             attempt=job.attempt if job.attempt is not None else registry_job.attempt,
             exit_code=job.exit_code if job.exit_code is not None else registry_job.exit_code,
             status_reason=job.status_reason or registry_job.status_reason,
+            termination_category=job.termination_category or registry_job.termination_category,
+            termination_source=job.termination_source or registry_job.termination_source,
+            termination_confidence=(
+                job.termination_confidence or registry_job.termination_confidence
+            ),
         )
 
     def _update_rule_stats_from_completions(self, progress: WorkflowProgress) -> None:

--- a/snakesee/tui/data_source.py
+++ b/snakesee/tui/data_source.py
@@ -1073,6 +1073,9 @@ class WorkflowDataSource:
             log_stream=job.log_stream or registry_job.log_stream,
             queue=job.queue or registry_job.queue,
             queued_at=job.queued_at if job.queued_at is not None else registry_job.queued_at,
+            attempt=job.attempt if job.attempt is not None else registry_job.attempt,
+            exit_code=job.exit_code if job.exit_code is not None else registry_job.exit_code,
+            status_reason=job.status_reason or registry_job.status_reason,
         )
 
     def _update_rule_stats_from_completions(self, progress: WorkflowProgress) -> None:

--- a/snakesee/tui/renderables.py
+++ b/snakesee/tui/renderables.py
@@ -65,6 +65,20 @@ def make_remote_job_info(job: "JobInfo") -> list[str]:
     if queue_wait is not None:
         lines.append(f"  queued for: {format_duration(queue_wait)}")
 
+    # Attempt > 1 means the job was retried/preempted; worth surfacing.
+    if job.attempt is not None and job.attempt > 1:
+        lines.append(f"  attempt: {job.attempt}")
+
+    if job.exit_code is not None:
+        lines.append(f"  exit code: {job.exit_code}")
+
+    if job.status_reason:
+        from snakesee.remote_links import is_spot_interruption
+
+        if is_spot_interruption(job.status_reason):
+            lines.append("  ⚠ spot interrupted")
+        lines.append(f"  reason: {job.status_reason}")
+
     console = batch_console_url(job.external_jobid, region=job.region)
     if console is not None:
         lines.append(f"  console: {console}")

--- a/snakesee/tui/renderables.py
+++ b/snakesee/tui/renderables.py
@@ -72,11 +72,21 @@ def make_remote_job_info(job: "JobInfo") -> list[str]:
     if job.exit_code is not None:
         lines.append(f"  exit code: {job.exit_code}")
 
-    if job.status_reason:
+    # Prefer the executor's structured termination classification (rendered with
+    # confidence). Fall back to snakesee's own low-confidence string heuristic only
+    # when no structured category arrived (e.g. an older executor).
+    from snakesee.remote_termination import format_termination_marker
+
+    marker = format_termination_marker(job.termination_category, job.termination_confidence)
+    if job.termination_category is None and job.status_reason:
         from snakesee.remote_links import is_spot_interruption
 
         if is_spot_interruption(job.status_reason):
-            lines.append("  ⚠ spot interrupted")
+            marker = "possibly spot interrupted"
+    if marker is not None:
+        lines.append(f"  {marker}")
+
+    if job.status_reason:
         lines.append(f"  reason: {job.status_reason}")
 
     console = batch_console_url(job.external_jobid, region=job.region)

--- a/tests/test_remote_observability.py
+++ b/tests/test_remote_observability.py
@@ -1,0 +1,158 @@
+"""Tests for deep remote observability: retries, exit codes, reasons, spot (Phase 3)."""
+
+from __future__ import annotations
+
+from snakesee.events import EventType
+from snakesee.events import SnakeseeEvent
+from snakesee.models import JobInfo
+from snakesee.remote_links import is_spot_interruption
+from snakesee.state.job_registry import JobRegistry
+from snakesee.tui.renderables import make_remote_job_info
+
+
+class TestSpotDetection:
+    def test_detects_spot_markers(self) -> None:
+        assert is_spot_interruption("Spot interruption: capacity reclaimed")
+        assert is_spot_interruption("EC2 Spot instance was reclaimed")
+        assert is_spot_interruption("Host EC2 (instance i-abc) terminated due to spot")
+
+    def test_non_spot_reasons(self) -> None:
+        assert not is_spot_interruption(None)
+        assert not is_spot_interruption("")
+        assert not is_spot_interruption("Essential container in task exited")
+        # Host terminated without any spot hint is not classified as spot.
+        assert not is_spot_interruption("Host EC2 (instance i-abc) terminated")
+
+
+class TestApplyEventPopulatesObservability:
+    def test_error_event_carries_exit_code_and_reason(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(
+            SnakeseeEvent(
+                event_type=EventType.JOB_ERROR,
+                timestamp=200.0,
+                job_id=7,
+                rule_name="align",
+                executor="aws-batch",
+                exit_code=137,
+                status_reason="Spot interruption: capacity reclaimed",
+                attempt=2,
+            )
+        )
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.exit_code == 137
+        assert job.status_reason == "Spot interruption: capacity reclaimed"
+        assert job.attempt == 2
+        info = job.to_job_info()
+        assert info.exit_code == 137
+        assert info.attempt == 2
+
+    def test_finished_event_carries_exit_code_zero(self) -> None:
+        # The common clean-finish path: exit_code 0 must survive (not be dropped
+        # as falsy) through apply_event and to_job_info.
+        reg = JobRegistry()
+        reg.apply_event(
+            SnakeseeEvent(
+                event_type=EventType.JOB_FINISHED,
+                timestamp=200.0,
+                job_id=7,
+                rule_name="align",
+                executor="aws-batch",
+                exit_code=0,
+                attempt=1,
+                stopped_at=200.0,
+            )
+        )
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.exit_code == 0
+        assert job.to_job_info().exit_code == 0
+
+    def test_job_info_round_trip_preserves_observability(self) -> None:
+        from snakesee.state.job_registry import Job
+
+        info = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            attempt=3,
+            exit_code=0,
+            status_reason="ok",
+        )
+        job = Job.from_job_info(info)
+        assert (job.attempt, job.exit_code, job.status_reason) == (3, 0, "ok")
+        back = job.to_job_info()
+        assert (back.attempt, back.exit_code, back.status_reason) == (3, 0, "ok")
+
+
+class TestEnrichRunningObservability:
+    """A running remote job's detail backfills observability fields from the registry."""
+
+    def test_running_job_backfills_exit_code_zero(
+        self, snakemake_dir: object, tmp_path: object
+    ) -> None:
+        from pathlib import Path
+
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.data_source import WorkflowDataSource
+
+        assert isinstance(tmp_path, Path)
+        ds = WorkflowDataSource(workflow_dir=tmp_path, use_estimation=False)
+        base = WorkflowProgress(
+            workflow_dir=tmp_path, status=WorkflowStatus.RUNNING, total_jobs=1, completed_jobs=0
+        )
+        # A started remote job whose registry record carries attempt/exit_code=0;
+        # the freshly-built running JobInfo must be backfilled (0 not dropped).
+        result = ds.apply_events_to_progress(
+            base,
+            [
+                SnakeseeEvent(
+                    event_type=EventType.JOB_STARTED,
+                    timestamp=150.0,
+                    job_id=7,
+                    rule_name="align",
+                    executor="aws-batch",
+                    external_jobid="arn:aws:batch:us-east-1:1:job/abc",
+                    attempt=2,
+                    exit_code=0,
+                    started_at=142.0,
+                )
+            ],
+        )
+        running = [j for j in result.running_jobs if j.job_id == "7"]
+        assert len(running) == 1
+        assert running[0].attempt == 2
+        assert running[0].exit_code == 0
+
+
+class TestObservabilityDisplay:
+    def test_failed_remote_job_shows_exit_code_reason_and_spot(self) -> None:
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="arn:aws:batch:us-east-1:1:job/abc",
+            executor="aws-batch",
+            attempt=2,
+            exit_code=137,
+            status_reason="Spot interruption: capacity reclaimed",
+        )
+        lines = make_remote_job_info(job)
+        assert any("attempt: 2" in line for line in lines)
+        assert any("exit code: 137" in line for line in lines)
+        assert any("spot interrupted" in line for line in lines)
+        assert any("reason:" in line and "capacity reclaimed" in line for line in lines)
+
+    def test_first_attempt_not_shown(self) -> None:
+        # attempt == 1 is the normal case; don't clutter the detail with it.
+        job = JobInfo(rule="align", job_id="7", external_jobid="abc", attempt=1)
+        lines = make_remote_job_info(job)
+        assert not any("attempt:" in line for line in lines)
+
+    def test_clean_success_has_no_reason_or_spot(self) -> None:
+        job = JobInfo(rule="align", job_id="7", external_jobid="abc", exit_code=0)
+        lines = make_remote_job_info(job)
+        assert any("exit code: 0" in line for line in lines)
+        assert not any("spot interrupted" in line for line in lines)
+        assert not any("reason:" in line for line in lines)

--- a/tests/test_remote_termination.py
+++ b/tests/test_remote_termination.py
@@ -1,0 +1,117 @@
+"""Tests for the termination value-set and confidence-aware rendering."""
+
+from __future__ import annotations
+
+from snakesee.remote_termination import CONFIDENCE_HIGH
+from snakesee.remote_termination import CONFIDENCE_LOW
+from snakesee.remote_termination import TERM_OOM
+from snakesee.remote_termination import TERM_SPOT
+from snakesee.remote_termination import TERM_UNKNOWN
+from snakesee.remote_termination import format_termination_marker
+
+
+class TestFormatTerminationMarker:
+    def test_high_confidence_spot(self) -> None:
+        assert format_termination_marker(TERM_SPOT, CONFIDENCE_HIGH) == "⚠ spot interrupted"
+
+    def test_low_confidence_spot_is_tentative(self) -> None:
+        # A guessed classification must read as tentative, not asserted.
+        assert format_termination_marker(TERM_SPOT, CONFIDENCE_LOW) == "possibly spot interrupted"
+
+    def test_high_confidence_oom(self) -> None:
+        assert format_termination_marker(TERM_OOM, CONFIDENCE_HIGH) == "⚠ out of memory"
+
+    def test_unknown_category_has_no_marker(self) -> None:
+        # Don't render a marker for an unclassified termination.
+        assert format_termination_marker(TERM_UNKNOWN, CONFIDENCE_HIGH) is None
+
+    def test_none_category_has_no_marker(self) -> None:
+        assert format_termination_marker(None, CONFIDENCE_HIGH) is None
+
+    def test_missing_confidence_defaults_to_tentative(self) -> None:
+        # If confidence is unknown, be conservative and phrase it tentatively.
+        assert format_termination_marker(TERM_SPOT, None) == "possibly spot interrupted"
+
+    def test_unrecognized_category_passthrough_lowercased(self) -> None:
+        # A category snakesee doesn't have a friendly label for still renders
+        # (forward-compat with executors that send new categories).
+        assert format_termination_marker("preempted", CONFIDENCE_HIGH) == "⚠ preempted"
+
+
+class TestTerminationEndToEnd:
+    """Structured termination flows event -> registry -> JobInfo -> render."""
+
+    def test_apply_event_populates_termination(self) -> None:
+        from snakesee.events import EventType
+        from snakesee.events import SnakeseeEvent
+        from snakesee.state.job_registry import JobRegistry
+
+        reg = JobRegistry()
+        reg.apply_event(
+            SnakeseeEvent(
+                event_type=EventType.JOB_ERROR,
+                timestamp=200.0,
+                job_id=7,
+                rule_name="align",
+                executor="aws-batch",
+                status_reason="Host EC2 (instance i-abc) terminated.",
+                termination_category=TERM_SPOT,
+                termination_source="aws_instance_state",
+                termination_confidence=CONFIDENCE_HIGH,
+            )
+        )
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.termination_category == TERM_SPOT
+        assert job.termination_confidence == CONFIDENCE_HIGH
+        assert job.to_job_info().termination_source == "aws_instance_state"
+
+    def test_high_confidence_structured_renders_firm_marker(self) -> None:
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        # statusReason has no "spot" token, so the string heuristic would miss it,
+        # but the high-confidence structured classification renders firmly.
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            status_reason="Host EC2 (instance i-abc) terminated.",
+            termination_category=TERM_SPOT,
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        lines = make_remote_job_info(job)
+        assert any("⚠ spot interrupted" in line for line in lines)
+        assert not any("possibly" in line for line in lines)
+
+    def test_string_heuristic_fallback_is_tentative(self) -> None:
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        # No structured category: fall back to the string heuristic, phrased tentatively.
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            status_reason="Spot interruption: capacity reclaimed",
+        )
+        lines = make_remote_job_info(job)
+        assert any("possibly spot interrupted" in line for line in lines)
+
+    def test_plugin_adapter_passes_termination_through(self) -> None:
+        # The plugin's reader-side event also carries the fields after JSON round trip.
+        import orjson
+
+        from snakesee.events import SnakeseeEvent
+
+        payload = {
+            "event_type": "job_error",
+            "timestamp": 200.0,
+            "job_id": 7,
+            "termination_category": "spot",
+            "termination_source": "aws_instance_state",
+            "termination_confidence": "high",
+        }
+        event = SnakeseeEvent.from_json(orjson.dumps(payload))
+        assert event.termination_category == "spot"
+        assert event.termination_confidence == "high"

--- a/tests/test_remote_termination.py
+++ b/tests/test_remote_termination.py
@@ -2,12 +2,35 @@
 
 from __future__ import annotations
 
+from snakesee import remote_termination
 from snakesee.remote_termination import CONFIDENCE_HIGH
 from snakesee.remote_termination import CONFIDENCE_LOW
 from snakesee.remote_termination import TERM_OOM
 from snakesee.remote_termination import TERM_SPOT
 from snakesee.remote_termination import TERM_UNKNOWN
 from snakesee.remote_termination import format_termination_marker
+
+
+class TestContractValues:
+    """Lock the wire strings of the published value set (the contract surface)."""
+
+    def test_category_wire_strings(self) -> None:
+        assert remote_termination.TERM_SPOT == "spot"
+        assert remote_termination.TERM_OOM == "oom"
+        assert remote_termination.TERM_TIMEOUT == "timeout"
+        assert remote_termination.TERM_NODE_FAILURE == "node_failure"
+        assert remote_termination.TERM_CANCELLED == "cancelled"
+        assert remote_termination.TERM_DEPENDENCY == "dependency"
+        assert remote_termination.TERM_IMAGE_PULL == "image_pull"
+        assert remote_termination.TERM_UNKNOWN == "unknown"
+
+    def test_confidence_and_source_wire_strings(self) -> None:
+        assert remote_termination.CONFIDENCE_HIGH == "high"
+        assert remote_termination.CONFIDENCE_LOW == "low"
+        assert remote_termination.SOURCE_EVENTBRIDGE == "eventbridge"
+        assert remote_termination.SOURCE_AWS_INSTANCE_STATE == "aws_instance_state"
+        assert remote_termination.SOURCE_EXECUTOR_HEURISTIC == "executor_heuristic"
+        assert remote_termination.SOURCE_STATUS_REASON == "status_reason"
 
 
 class TestFormatTerminationMarker:
@@ -84,6 +107,64 @@ class TestTerminationEndToEnd:
         assert any("⚠ spot interrupted" in line for line in lines)
         assert not any("possibly" in line for line in lines)
 
+    def test_structured_suppresses_string_heuristic(self) -> None:
+        # When a high-confidence classification AND a spot-matching status_reason
+        # both exist, exactly one (firm) marker renders — the heuristic is suppressed.
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            status_reason="Spot interruption: capacity reclaimed",  # would match heuristic
+            termination_category=TERM_SPOT,
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        lines = make_remote_job_info(job)
+        markers = [line for line in lines if "spot interrupted" in line]
+        assert len(markers) == 1
+        assert "⚠ spot interrupted" in markers[0]
+        assert "possibly" not in markers[0]
+
+    def test_explicit_unknown_suppresses_string_heuristic(self) -> None:
+        # An explicit TERM_UNKNOWN is still a structured classification: the executor
+        # looked and could not tell. The string heuristic must not override it.
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            status_reason="Spot interruption: capacity reclaimed",  # would match heuristic
+            termination_category=TERM_UNKNOWN,
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        lines = make_remote_job_info(job)
+        assert not any("spot interrupted" in line for line in lines)
+
+    def test_from_job_info_round_trip(self) -> None:
+        from snakesee.models import JobInfo
+        from snakesee.state.job_registry import Job
+
+        info = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            termination_category=TERM_SPOT,
+            termination_source="aws_instance_state",
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        job = Job.from_job_info(info)
+        assert job.termination_category == TERM_SPOT
+        assert job.termination_source == "aws_instance_state"
+        assert job.termination_confidence == CONFIDENCE_HIGH
+        back = job.to_job_info()
+        assert back.termination_category == TERM_SPOT
+        assert back.termination_source == "aws_instance_state"
+        assert back.termination_confidence == CONFIDENCE_HIGH
+
     def test_string_heuristic_fallback_is_tentative(self) -> None:
         from snakesee.models import JobInfo
         from snakesee.tui.renderables import make_remote_job_info
@@ -114,4 +195,5 @@ class TestTerminationEndToEnd:
         }
         event = SnakeseeEvent.from_json(orjson.dumps(payload))
         assert event.termination_category == "spot"
+        assert event.termination_source == "aws_instance_state"
         assert event.termination_confidence == "high"


### PR DESCRIPTION
Builds on #72. Richer remote-job state.

- Retry count, exit code, failure reason, and a spot-interruption marker in the job detail.
- Typed termination model (category/source/confidence), rendered by confidence — high-confidence stated firmly, heuristic tentatively.
- Logger-plugin adapter accepts a backend-neutral contract (groundwork for standardizing remote-job-state across executors).

Stacked on #72; review/merge after it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved remote job diagnostics: termination classification (spot, OOM, timeout, node failure, cancelled, etc.), plus graceful display of confidence and source.
  * UI now shows retry attempts (>1), exit codes, and termination reason/marker; structured termination markers preferred over heuristic strings.
  * Broader payload support so remote-state payloads in multiple formats are recognized and preserved end-to-end.

* **Tests**
  * Added extensive tests covering observability, termination formatting, payload formats, and round-trip preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->