### PR TITLE
feat: estimated cost for remote jobs

### DIFF
--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/events.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/events.py
@@ -52,6 +52,7 @@ class SnakeseeEvent:
         termination_category: Why the job died (e.g. "spot", "oom"), if classified.
         termination_source: Provenance of the classification (e.g. "aws_instance_state").
         termination_confidence: How sure the producer was ("high" / "low").
+        cost_estimate: Estimated USD cost of the job (list/market price, not billed).
     """
 
     event_type: EventType
@@ -84,6 +85,7 @@ class SnakeseeEvent:
     termination_category: str | None = None
     termination_source: str | None = None
     termination_confidence: str | None = None
+    cost_estimate: float | None = None
 
     def to_json(self) -> str:
         """Serialize to compact JSON string.

--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/remote_adapter.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/remote_adapter.py
@@ -16,6 +16,7 @@ spec, and each side implements it.
 
 from __future__ import annotations
 
+import math
 from typing import Any, Final
 
 from snakemake_logger_plugin_snakesee.events import EventType, SnakeseeEvent
@@ -126,6 +127,7 @@ def event_from_payload(payload: Any, timestamp: float) -> SnakeseeEvent | None:
         termination_category=_opt_str(payload.get("termination_category")),
         termination_source=_opt_str(payload.get("termination_source")),
         termination_confidence=_opt_str(payload.get("termination_confidence")),
+        cost_estimate=_opt_float(payload.get("cost_estimate")),
         duration=duration,
         # Surface the failure reason as the error message for JOB_ERROR events.
         error_message=status_reason if event_type == EventType.JOB_ERROR else None,
@@ -148,10 +150,15 @@ def _opt_int(value: Any) -> int | None:
 
 
 def _opt_float(value: Any) -> float | None:
-    """Coerce an optional value to float, returning None on failure."""
+    """Coerce an optional value to float, returning None on failure or for non-finite values.
+
+    Non-finite results (nan/inf/-inf) are treated as failures so a single malformed payload
+    cannot poison sums such as ``JobRegistry.total_cost_estimate()``.
+    """
     if value is None or isinstance(value, bool):
         return None
     try:
-        return float(value)
+        result = float(value)
     except (TypeError, ValueError):
         return None
+    return result if math.isfinite(result) else None

--- a/snakemake-logger-plugin-snakesee/tests/test_remote_adapter.py
+++ b/snakemake-logger-plugin-snakesee/tests/test_remote_adapter.py
@@ -62,6 +62,21 @@ class TestEventFromPayload:
         assert event.status_reason == "OOM killed"
         assert event.exit_code == 137
 
+    def test_cost_estimate_carried(self) -> None:
+        event = event_from_payload(_payload(phase="succeeded", cost_estimate=0.0456), timestamp=1.0)
+        assert event is not None
+        assert event.cost_estimate == 0.0456
+
+    def test_non_finite_cost_estimate_dropped(self) -> None:
+        # nan/inf must not propagate: a single malformed payload would otherwise
+        # poison JobRegistry.total_cost_estimate(), which sums every non-None value.
+        for bad in ("nan", "inf", "-inf"):
+            event = event_from_payload(
+                _payload(phase="succeeded", cost_estimate=bad), timestamp=1.0
+            )
+            assert event is not None
+            assert event.cost_estimate is None, f"{bad!r} should be dropped"
+
     def test_termination_fields_carried(self) -> None:
         event = event_from_payload(
             _payload(

--- a/snakesee/events.py
+++ b/snakesee/events.py
@@ -72,6 +72,7 @@ class SnakeseeEvent:
         termination_category: Why the job died (e.g. "spot", "oom"), if classified.
         termination_source: Provenance of the classification (e.g. "aws_instance_state").
         termination_confidence: How sure the producer was ("high" / "low").
+        cost_estimate: Estimated USD cost of the job (list/market price, not billed).
     """
 
     event_type: EventType
@@ -104,6 +105,7 @@ class SnakeseeEvent:
     termination_category: str | None = None
     termination_source: str | None = None
     termination_confidence: str | None = None
+    cost_estimate: float | None = None
 
     @classmethod
     def from_json(cls, json_str: str | bytes) -> "SnakeseeEvent":

--- a/snakesee/models.py
+++ b/snakesee/models.py
@@ -1,6 +1,8 @@
 """Data models for workflow monitoring."""
 
 import logging
+import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from dataclasses import field
 from enum import Enum
@@ -61,6 +63,7 @@ class JobInfo:
         termination_category: Why the job died (e.g. "spot", "oom"), if classified.
         termination_source: Provenance of the classification (e.g. "aws_instance_state").
         termination_confidence: How sure the producer was ("high" / "low").
+        cost_estimate: Estimated USD cost of the job (list/market price, not billed).
     """
 
     rule: str
@@ -84,6 +87,17 @@ class JobInfo:
     termination_category: str | None = None
     termination_source: str | None = None
     termination_confidence: str | None = None
+    cost_estimate: float | None = None
+
+    def __post_init__(self) -> None:
+        """Drop a non-finite cost_estimate so nan/inf cannot poison cost aggregates.
+
+        Mirrors ``_opt_float`` in the remote logger adapter: every producer of this model
+        (direct construction as well as event ingestion) enforces the same finite-or-None
+        invariant that ``JobRegistry.total_cost_estimate()`` relies on.
+        """
+        if self.cost_estimate is not None and not math.isfinite(self.cost_estimate):
+            object.__setattr__(self, "cost_estimate", None)
 
     @property
     def queue_wait(self) -> float | None:
@@ -687,7 +701,7 @@ class TimeEstimate:
         )
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class WorkflowProgress:
     """
     Current state of workflow progress.
@@ -698,28 +712,52 @@ class WorkflowProgress:
         total_jobs: Total number of jobs in the workflow.
         completed_jobs: Number of jobs completed.
         failed_jobs: Number of jobs that failed.
-        failed_jobs_list: List of failed job details (for --keep-going).
-        incomplete_jobs_list: List of jobs that were in progress when workflow was interrupted.
-        running_jobs: List of currently running jobs.
-        queued_jobs_list: List of jobs queued on a remote executor (awaiting a node).
-        recent_completions: List of recently completed jobs.
+        failed_jobs_list: Failed job details (for --keep-going).
+        incomplete_jobs_list: Jobs that were in progress when the workflow was interrupted.
+        running_jobs: Currently running jobs.
+        queued_jobs_list: Jobs queued on a remote executor (awaiting a node).
+        recent_completions: Recently completed jobs.
         start_time: Unix timestamp when workflow started.
         log_file: Path to the current snakemake log file.
     """
+
+    # Job collections are typed as read-only ``Sequence`` and normalized to tuples in
+    # __post_init__ so this frozen snapshot is immutable all the way down: callers can still
+    # pass lists at construction (a list is a Sequence), but the stored value cannot be
+    # mutated in place. JobInfo is itself frozen, so the snapshot is deeply immutable.
+    _JOB_SEQUENCE_FIELDS: ClassVar[tuple[str, ...]] = (
+        "failed_jobs_list",
+        "incomplete_jobs_list",
+        "running_jobs",
+        "recent_completions",
+        "pending_jobs_list",
+        "queued_jobs_list",
+    )
 
     workflow_dir: Path
     status: WorkflowStatus
     total_jobs: int
     completed_jobs: int
     failed_jobs: int = 0
-    failed_jobs_list: list[JobInfo] = field(default_factory=list)
-    incomplete_jobs_list: list[JobInfo] = field(default_factory=list)
-    running_jobs: list[JobInfo] = field(default_factory=list)
-    recent_completions: list[JobInfo] = field(default_factory=list)
-    pending_jobs_list: list[JobInfo] = field(default_factory=list)
-    queued_jobs_list: list[JobInfo] = field(default_factory=list)
+    failed_jobs_list: Sequence[JobInfo] = ()
+    incomplete_jobs_list: Sequence[JobInfo] = ()
+    running_jobs: Sequence[JobInfo] = ()
+    recent_completions: Sequence[JobInfo] = ()
+    pending_jobs_list: Sequence[JobInfo] = ()
+    queued_jobs_list: Sequence[JobInfo] = ()
     start_time: float | None = None
     log_file: Path | None = None
+    total_cost_estimate: float | None = None
+
+    def __post_init__(self) -> None:
+        """Freeze each job collection into a tuple and drop a non-finite total cost."""
+        for field_name in self._JOB_SEQUENCE_FIELDS:
+            value = getattr(self, field_name)
+            if not isinstance(value, tuple):
+                object.__setattr__(self, field_name, tuple(value))
+        # Drop a non-finite workflow total so nan/inf cannot poison the header summary.
+        if self.total_cost_estimate is not None and not math.isfinite(self.total_cost_estimate):
+            object.__setattr__(self, "total_cost_estimate", None)
 
     @property
     def percent_complete(self) -> float:

--- a/snakesee/state/job_registry.py
+++ b/snakesee/state/job_registry.py
@@ -60,6 +60,7 @@ class Job:
         termination_category: Why the job died (e.g. "spot", "oom"), if classified.
         termination_source: Provenance of the classification (e.g. "aws_instance_state").
         termination_confidence: How sure the producer was ("high" / "low").
+        cost_estimate: Estimated USD cost of the job (list/market price, not billed).
     """
 
     key: str
@@ -84,6 +85,7 @@ class Job:
     termination_category: str | None = None
     termination_source: str | None = None
     termination_confidence: str | None = None
+    cost_estimate: float | None = None
     stats_recorded: bool = False
 
     @property
@@ -142,6 +144,7 @@ class Job:
             termination_category=self.termination_category,
             termination_source=self.termination_source,
             termination_confidence=self.termination_confidence,
+            cost_estimate=self.cost_estimate,
         )
 
     @classmethod
@@ -184,6 +187,7 @@ class Job:
             termination_category=job_info.termination_category,
             termination_source=job_info.termination_source,
             termination_confidence=job_info.termination_confidence,
+            cost_estimate=job_info.cost_estimate,
         )
 
 
@@ -360,6 +364,14 @@ class JobRegistry:
         """Get queued (remote, awaiting node) jobs as JobInfo."""
         return [job.to_job_info() for job in self.queued()]
 
+    def total_cost_estimate(self) -> float | None:
+        """Sum of per-job cost estimates across all jobs, or None if none have one."""
+        with self._lock:
+            costs = [
+                job.cost_estimate for job in self._jobs.values() if job.cost_estimate is not None
+            ]
+        return sum(costs) if costs else None
+
     def clear(self) -> None:
         """Clear all jobs from the registry."""
         with self._lock:
@@ -533,6 +545,8 @@ class JobRegistry:
             job.termination_source = event.termination_source
         if event.termination_confidence is not None:
             job.termination_confidence = event.termination_confidence
+        if event.cost_estimate is not None:
+            job.cost_estimate = event.cost_estimate
         if event.queued_at is not None and job.queued_at is None:
             job.queued_at = event.queued_at
 

--- a/snakesee/state/job_registry.py
+++ b/snakesee/state/job_registry.py
@@ -372,6 +372,15 @@ class JobRegistry:
             ]
         return sum(costs) if costs else None
 
+    def cost_by_rule(self) -> dict[str, float]:
+        """Sum of per-job cost estimates grouped by rule (only rules with cost)."""
+        totals: dict[str, float] = {}
+        with self._lock:
+            for job in self._jobs.values():
+                if job.cost_estimate is not None:
+                    totals[job.rule] = totals.get(job.rule, 0.0) + job.cost_estimate
+        return totals
+
     def clear(self) -> None:
         """Clear all jobs from the registry."""
         with self._lock:

--- a/snakesee/tui/app.py
+++ b/snakesee/tui/app.py
@@ -33,6 +33,7 @@ from snakesee.tui.accessibility import DEFAULT_CONFIG
 from snakesee.tui.accessibility import AccessibilityConfig
 from snakesee.tui.data_source import SortTableName
 from snakesee.tui.data_source import WorkflowDataSource
+from snakesee.tui.renderables import format_cost
 from snakesee.tui.renderables import make_header
 from snakesee.tui.renderables import make_progress_panel
 from snakesee.tui.renderables import make_summary_footer
@@ -654,6 +655,14 @@ class SnakeseeApp(App[None]):
             sort_column=self.sort_column,
             sort_ascending=self.sort_ascending,
         )
+        # Add a Cost column the first time any estimated cost is available, so
+        # runs without cost estimation never get a blank column.
+        show_cost = progress.total_cost_estimate is not None
+        if show_cost and not getattr(self, "_completions_cost_col", False):
+            table.add_column("Cost", key="cost")
+            self._completions_cost_col = True
+        has_cost_col = getattr(self, "_completions_cost_col", False)
+
         rows = completion_rows(jobs, failed_job_ids)
         for idx, row in enumerate(rows):
             job = row.job
@@ -663,7 +672,12 @@ class SnakeseeApp(App[None]):
             if job.end_time is not None:
                 completed_str = datetime.fromtimestamp(job.end_time).strftime("%H:%M:%S")
             job_id_str = str(job.job_id) if job.job_id else str(idx + 1)
-            table.add_row(job_id_str, job.rule, threads_str, duration_str, completed_str)
+            cells = [job_id_str, job.rule, threads_str, duration_str, completed_str]
+            if has_cost_col:
+                cells.append(
+                    format_cost(job.cost_estimate) if job.cost_estimate is not None else "-"
+                )
+            table.add_row(*cells)
 
     def _populate_pending(self, progress: WorkflowProgress) -> None:
         """Populate the pending-jobs table using inferred per-rule pending counts."""
@@ -709,11 +723,23 @@ class SnakeseeApp(App[None]):
         rows = stats_rows(stats_list, self._data.thread_stats_dict())
         if self.sort_table == SortTable.STATS:
             rows = sort_stats_rows(rows, self.sort_column, self.sort_ascending)
+
+        # Per-rule estimated cost: add a Cost column once any cost data exists.
+        cost_by_rule = self._data.cost_by_rule()
+        if cost_by_rule and not getattr(self, "_stats_cost_col", False):
+            table.add_column("Cost", key="cost")
+            self._stats_cost_col = True
+        has_cost_col = getattr(self, "_stats_cost_col", False)
+
         for row in rows:
-            table.add_row(
+            cells = [
                 row.rule_display,
                 row.threads,
                 str(row.stats.count),
                 format_duration(row.stats.mean_duration),
                 format_duration(row.stats.std_dev) if row.stats.std_dev > 0 else "-",
-            )
+            ]
+            if has_cost_col:
+                rule_cost = cost_by_rule.get(row.stats.rule)
+                cells.append(format_cost(rule_cost) if rule_cost is not None else "-")
+            table.add_row(*cells)

--- a/snakesee/tui/app.py
+++ b/snakesee/tui/app.py
@@ -522,6 +522,11 @@ class SnakeseeApp(App[None]):
         # is running. The ignore works around Textual's stubs typing class-level reactive
         # access as the value type (float) rather than Reactive[float].
         self.set_reactive(SnakeseeApp.refresh_rate, refresh_rate)  # type: ignore[arg-type]
+        # Whether the (lazily-added) Cost columns have been added to the
+        # completions / stats tables. Once True they stay — the column and flag
+        # must always move together to avoid an add_row cell-count mismatch.
+        self._completions_cost_col: bool = False
+        self._stats_cost_col: bool = False
 
     def compose(self) -> ComposeResult:
         """Compose the widget tree (header / progress / six tables / summary / footer)."""
@@ -657,11 +662,9 @@ class SnakeseeApp(App[None]):
         )
         # Add a Cost column the first time any estimated cost is available, so
         # runs without cost estimation never get a blank column.
-        show_cost = progress.total_cost_estimate is not None
-        if show_cost and not getattr(self, "_completions_cost_col", False):
+        if progress.total_cost_estimate is not None and not self._completions_cost_col:
             table.add_column("Cost", key="cost")
             self._completions_cost_col = True
-        has_cost_col = getattr(self, "_completions_cost_col", False)
 
         rows = completion_rows(jobs, failed_job_ids)
         for idx, row in enumerate(rows):
@@ -673,7 +676,7 @@ class SnakeseeApp(App[None]):
                 completed_str = datetime.fromtimestamp(job.end_time).strftime("%H:%M:%S")
             job_id_str = str(job.job_id) if job.job_id else str(idx + 1)
             cells = [job_id_str, job.rule, threads_str, duration_str, completed_str]
-            if has_cost_col:
+            if self._completions_cost_col:
                 cells.append(
                     format_cost(job.cost_estimate) if job.cost_estimate is not None else "-"
                 )
@@ -725,11 +728,12 @@ class SnakeseeApp(App[None]):
             rows = sort_stats_rows(rows, self.sort_column, self.sort_ascending)
 
         # Per-rule estimated cost: add a Cost column once any cost data exists.
+        # Sourced from the live registry (the stats panel is itself registry-backed,
+        # so this stays consistent with the rest of the stats frame).
         cost_by_rule = self._data.cost_by_rule()
-        if cost_by_rule and not getattr(self, "_stats_cost_col", False):
+        if cost_by_rule and not self._stats_cost_col:
             table.add_column("Cost", key="cost")
             self._stats_cost_col = True
-        has_cost_col = getattr(self, "_stats_cost_col", False)
 
         for row in rows:
             cells = [
@@ -739,7 +743,7 @@ class SnakeseeApp(App[None]):
                 format_duration(row.stats.mean_duration),
                 format_duration(row.stats.std_dev) if row.stats.std_dev > 0 else "-",
             ]
-            if has_cost_col:
+            if self._stats_cost_col:
                 rule_cost = cost_by_rule.get(row.stats.rule)
                 cells.append(format_cost(rule_cost) if rule_cost is not None else "-")
             table.add_row(*cells)

--- a/snakesee/tui/data_source.py
+++ b/snakesee/tui/data_source.py
@@ -14,6 +14,7 @@ import logging
 import math
 import time
 from collections.abc import Iterable
+from collections.abc import Sequence
 from contextlib import AbstractContextManager
 from contextlib import nullcontext
 from pathlib import Path
@@ -900,9 +901,9 @@ class WorkflowDataSource:
 
     def _compute_pending_jobs_from_scheduled(
         self,
-        running_jobs: list[JobInfo],
-        completions: list[JobInfo],
-        failed_jobs: list[JobInfo] | None = None,
+        running_jobs: Sequence[JobInfo],
+        completions: Sequence[JobInfo],
+        failed_jobs: Sequence[JobInfo] | None = None,
     ) -> list[JobInfo]:
         """Compute pending jobs by subtracting running/completed/failed from all scheduled.
 
@@ -1046,6 +1047,7 @@ class WorkflowDataSource:
             queued_jobs_list=queued_jobs_list,
             start_time=progress.start_time,
             log_file=progress.log_file,
+            total_cost_estimate=self._workflow_state.jobs.total_cost_estimate(),
         )
 
     def _enrich_remote_fields(self, job: JobInfo) -> JobInfo:
@@ -1080,6 +1082,9 @@ class WorkflowDataSource:
             termination_source=job.termination_source or registry_job.termination_source,
             termination_confidence=(
                 job.termination_confidence or registry_job.termination_confidence
+            ),
+            cost_estimate=(
+                job.cost_estimate if job.cost_estimate is not None else registry_job.cost_estimate
             ),
         )
 
@@ -1126,18 +1131,18 @@ class WorkflowDataSource:
             registry_job.stats_recorded = True
 
     # --------------------------------------------------- filter / sort helpers
-    def filter_jobs(self, jobs: list[JobInfo], filter_text: str | None) -> list[JobInfo]:
+    def filter_jobs(self, jobs: Sequence[JobInfo], filter_text: str | None) -> list[JobInfo]:
         """Filter jobs by rule name if filter is active.
 
         Args:
-            jobs: List of jobs to filter.
+            jobs: Jobs to filter.
             filter_text: Text to filter by (case-insensitive substring match).
 
         Returns:
             Filtered list of jobs (all jobs if filter_text is empty).
         """
         if not filter_text:
-            return jobs
+            return list(jobs)
 
         return [j for j in jobs if filter_text.lower() in j.rule.lower()]
 

--- a/snakesee/tui/data_source.py
+++ b/snakesee/tui/data_source.py
@@ -281,6 +281,10 @@ class WorkflowDataSource:
         """Return per-rule, per-thread timing statistics."""
         return self._workflow_state.rules.to_thread_stats_dict()
 
+    def cost_by_rule(self) -> dict[str, float]:
+        """Return summed estimated cost per rule (empty when no cost data)."""
+        return self._workflow_state.jobs.cost_by_rule()
+
     # ------------------------------------------------------------------ logs
     def refresh_log_list(self) -> None:
         """Refresh the list of available log files."""

--- a/snakesee/tui/renderables.py
+++ b/snakesee/tui/renderables.py
@@ -34,6 +34,11 @@ FG_GREEN = "#38b44a"
 FG_LOGO_PATH = Path(__file__).parent.parent / "assets" / "logo.png"
 
 
+def format_cost(usd: float) -> str:
+    """Format a USD cost: 4 decimals under $1 (per-job costs are tiny), else 2."""
+    return f"${usd:.4f}" if usd < 1 else f"${usd:,.2f}"
+
+
 def make_remote_job_info(job: "JobInfo") -> list[str]:
     """Build display lines describing a remote job's external identifier and links.
 
@@ -88,6 +93,9 @@ def make_remote_job_info(job: "JobInfo") -> list[str]:
 
     if job.status_reason:
         lines.append(f"  reason: {job.status_reason}")
+
+    if job.cost_estimate is not None:
+        lines.append(f"  est. cost: {format_cost(job.cost_estimate)}")
 
     console = batch_console_url(job.external_jobid, region=job.region)
     if console is not None:
@@ -170,6 +178,12 @@ def make_header(
     if queued_count > 0:
         header_text.append("  │  Queued: ")
         header_text.append(str(queued_count), style="bold yellow")
+
+    # Estimated workflow cost so far (remote executors with cost estimation on).
+    if progress.total_cost_estimate is not None:
+        header_text.append("  │  Cost: ")
+        header_text.append(f"~{format_cost(progress.total_cost_estimate)}", style=FG_GREEN)
+        header_text.append(" (est)", style="dim")
 
     if paused:
         header_text.append("  │  ")

--- a/tests/test_app_tables.py
+++ b/tests/test_app_tables.py
@@ -86,3 +86,73 @@ async def test_tables_present_when_no_data(snakemake_dir: Path, tmp_path: Path) 
                 table = app.query_one(f"#{table_id}", DataTable)
                 assert table.row_count == 0
             await pilot.press("q")
+
+
+async def test_completions_cost_column_appears_with_cost(
+    snakemake_dir: Path, tmp_path: Path
+) -> None:
+    """The completions table gains a Cost column + cell when cost data is present."""
+    from dataclasses import replace
+
+    from snakesee.models import JobInfo
+
+    job = JobInfo(rule="align", job_id="2", start_time=900.0, end_time=930.0, cost_estimate=0.0123)
+    progress = replace(make_workflow_progress(recent_completions=[job]), total_cost_estimate=0.0123)
+    app = SnakeseeApp(workflow_dir=tmp_path)
+    with patch.object(app._data, "poll_state", return_value=(progress, None)):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.query_one("#completions", DataTable)
+            assert len(table.columns) == 6  # #, Rule, Thr, Duration, Completed, Cost
+            row = table.get_row_at(0)
+            assert "$0.0123" in row
+            await pilot.press("q")
+
+
+async def test_completions_no_cost_column_without_cost(snakemake_dir: Path, tmp_path: Path) -> None:
+    """No Cost column for a run without cost estimates."""
+    progress = make_workflow_progress(
+        recent_completions=[
+            make_job_info(job_id="2", rule="trim", start_time=900.0, end_time=930.0)
+        ],
+    )
+    app = SnakeseeApp(workflow_dir=tmp_path)
+    with patch.object(app._data, "poll_state", return_value=(progress, None)):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert len(app.query_one("#completions", DataTable).columns) == 5
+            await pilot.press("q")
+
+
+async def test_stats_cost_column_appears_with_cost(snakemake_dir: Path, tmp_path: Path) -> None:
+    """The Rule Statistics table gains a per-rule Cost column when cost data exists."""
+    from snakesee.events import EventType
+    from snakesee.events import SnakeseeEvent
+
+    progress = make_workflow_progress()
+    app = SnakeseeApp(workflow_dir=tmp_path)
+    with patch.object(app._data, "poll_state", return_value=(progress, None)):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Inject a rule stat + per-rule cost after mount (the initial refresh
+            # re-inits the estimator, which would clear pre-mount injections), then
+            # populate the stats table directly.
+            if app._data._estimator is not None:
+                app._data._estimator.current_rules = None
+                app._data._estimator._rule_registry.record_completion(
+                    rule="align", duration=100.0, timestamp=1.0
+                )
+            app._data._workflow_state.jobs.apply_event(
+                SnakeseeEvent(
+                    event_type=EventType.JOB_FINISHED,
+                    timestamp=1.0,
+                    job_id=7,
+                    rule_name="align",
+                    cost_estimate=0.5,
+                    stopped_at=1.0,
+                )
+            )
+            app._populate_stats()
+            table = app.query_one("#stats", DataTable)
+            assert len(table.columns) == 6  # Rule, Thr, Count, Avg, Std Dev, Cost
+            await pilot.press("q")

--- a/tests/test_app_tables.py
+++ b/tests/test_app_tables.py
@@ -124,6 +124,61 @@ async def test_completions_no_cost_column_without_cost(snakemake_dir: Path, tmp_
             await pilot.press("q")
 
 
+async def test_completions_cost_column_persists_then_blank(
+    snakemake_dir: Path, tmp_path: Path
+) -> None:
+    """Once added, the Cost column persists; a later cost-free frame renders '-' (no crash)."""
+    from dataclasses import replace
+
+    from snakesee.models import JobInfo
+
+    cost_job = JobInfo(
+        rule="align", job_id="2", start_time=900.0, end_time=930.0, cost_estimate=0.5
+    )
+    with_cost = replace(
+        make_workflow_progress(recent_completions=[cost_job]), total_cost_estimate=0.5
+    )
+    plain_job = make_job_info(job_id="3", rule="sort", start_time=900.0, end_time=930.0)
+    no_cost = make_workflow_progress(recent_completions=[plain_job])  # total_cost_estimate None
+
+    app = SnakeseeApp(workflow_dir=tmp_path)
+    with patch.object(app._data, "poll_state", return_value=(with_cost, None)):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.query_one("#completions", DataTable)
+            assert len(table.columns) == 6
+            # Second frame has no cost: the column persists and the cell is "-".
+            app._populate_completions(no_cost)
+            assert len(table.columns) == 6  # column did not disappear
+            assert table.row_count == 1
+            assert "-" in table.get_row_at(0)  # cost cell rendered as "-", no mismatch
+            await pilot.press("q")
+
+
+async def test_completions_mixed_cost_and_blank_cells(snakemake_dir: Path, tmp_path: Path) -> None:
+    """A job with cost and one without render their cells correctly in the same table."""
+    from dataclasses import replace
+
+    from snakesee.models import JobInfo
+
+    priced = JobInfo(
+        rule="align", job_id="2", start_time=900.0, end_time=930.0, cost_estimate=0.0123
+    )
+    free = JobInfo(rule="sort", job_id="3", start_time=900.0, end_time=930.0)
+    progress = replace(
+        make_workflow_progress(recent_completions=[priced, free]), total_cost_estimate=0.0123
+    )
+    app = SnakeseeApp(workflow_dir=tmp_path)
+    with patch.object(app._data, "poll_state", return_value=(progress, None)):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.query_one("#completions", DataTable)
+            costs = {table.get_row_at(i)[1]: table.get_row_at(i)[5] for i in range(table.row_count)}
+            assert costs["align"] == "$0.0123"
+            assert costs["sort"] == "-"
+            await pilot.press("q")
+
+
 async def test_stats_cost_column_appears_with_cost(snakemake_dir: Path, tmp_path: Path) -> None:
     """The Rule Statistics table gains a per-rule Cost column when cost data exists."""
     from snakesee.events import EventType

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 """Tests for monitor data models."""
 
+import math
 import time
 from pathlib import Path
 
@@ -89,6 +90,17 @@ class TestJobInfo:
         future_start = time.time() + 1000
         job = JobInfo(rule="test", start_time=future_start)
         assert job.elapsed == 0.0
+
+    def test_finite_cost_estimate_preserved(self) -> None:
+        """A finite cost_estimate (including 0.0) is stored unchanged."""
+        assert JobInfo(rule="test", cost_estimate=0.0).cost_estimate == 0.0
+        assert JobInfo(rule="test", cost_estimate=1.25).cost_estimate == 1.25
+        assert JobInfo(rule="test").cost_estimate is None
+
+    def test_non_finite_cost_estimate_dropped(self) -> None:
+        """nan/inf/-inf cost values are dropped to None so they cannot poison aggregates."""
+        for bad in (math.nan, math.inf, -math.inf):
+            assert JobInfo(rule="test", cost_estimate=bad).cost_estimate is None
 
 
 class TestRuleTimingStats:
@@ -466,6 +478,44 @@ class TestTimeEstimate:
 
 class TestWorkflowProgress:
     """Tests for the WorkflowProgress dataclass."""
+
+    def test_job_sequences_are_immutable_snapshots(self) -> None:
+        """List inputs are frozen into tuples so the snapshot cannot be mutated in place."""
+        source = [JobInfo(rule="a"), JobInfo(rule="b")]
+        progress = WorkflowProgress(
+            workflow_dir=Path("."),
+            status=WorkflowStatus.RUNNING,
+            total_jobs=10,
+            completed_jobs=0,
+            running_jobs=source,
+        )
+        # Stored as a tuple, decoupled from the source list...
+        assert isinstance(progress.running_jobs, tuple)
+        source.append(JobInfo(rule="c"))
+        assert len(progress.running_jobs) == 2
+        # ...and unset list fields default to an empty tuple, not a shared mutable list.
+        assert progress.failed_jobs_list == ()
+        assert isinstance(progress.recent_completions, tuple)
+
+    def test_non_finite_total_cost_estimate_dropped(self) -> None:
+        """nan/inf/-inf workflow totals are dropped to None so they cannot poison the header."""
+        for bad in (math.nan, math.inf, -math.inf):
+            progress = WorkflowProgress(
+                workflow_dir=Path("."),
+                status=WorkflowStatus.RUNNING,
+                total_jobs=10,
+                completed_jobs=0,
+                total_cost_estimate=bad,
+            )
+            assert progress.total_cost_estimate is None
+        finite = WorkflowProgress(
+            workflow_dir=Path("."),
+            status=WorkflowStatus.RUNNING,
+            total_jobs=10,
+            completed_jobs=0,
+            total_cost_estimate=2.5,
+        )
+        assert finite.total_cost_estimate == 2.5
 
     def test_percent_complete(self) -> None:
         """Test percent complete calculation."""

--- a/tests/test_remote_cost.py
+++ b/tests/test_remote_cost.py
@@ -1,0 +1,103 @@
+"""Tests for per-job and workflow cost estimate display (Phase 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from snakesee.events import EventType
+from snakesee.events import SnakeseeEvent
+from snakesee.models import JobInfo
+from snakesee.state.job_registry import JobRegistry
+from snakesee.tui.renderables import format_cost
+from snakesee.tui.renderables import make_remote_job_info
+
+
+class TestFormatCost:
+    def test_small_cost_four_decimals(self) -> None:
+        assert format_cost(0.0123) == "$0.0123"
+
+    def test_large_cost_two_decimals(self) -> None:
+        assert format_cost(1234.5) == "$1,234.50"
+
+
+class TestCostPlumbing:
+    def test_apply_event_populates_cost(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(
+            SnakeseeEvent(
+                event_type=EventType.JOB_FINISHED,
+                timestamp=200.0,
+                job_id=7,
+                rule_name="align",
+                executor="aws-batch",
+                cost_estimate=0.0456,
+                stopped_at=200.0,
+            )
+        )
+        job = reg.get_by_job_id("7")
+        assert job is not None
+        assert job.cost_estimate == 0.0456
+        assert job.to_job_info().cost_estimate == 0.0456
+
+    def test_total_cost_estimate_sums_jobs(self) -> None:
+        reg = JobRegistry()
+        for jid, cost in ((1, 0.10), (2, 0.05), (3, None)):
+            reg.apply_event(
+                SnakeseeEvent(
+                    event_type=EventType.JOB_FINISHED,
+                    timestamp=1.0,
+                    job_id=jid,
+                    rule_name="r",
+                    cost_estimate=cost,
+                    stopped_at=1.0,
+                )
+            )
+        assert reg.total_cost_estimate() == pytest.approx(0.15)
+
+    def test_total_cost_none_when_no_estimates(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(
+            SnakeseeEvent(event_type=EventType.JOB_FINISHED, timestamp=1.0, job_id=1, rule_name="r")
+        )
+        assert reg.total_cost_estimate() is None
+
+    def test_round_trip_preserves_cost(self) -> None:
+        from snakesee.state.job_registry import Job
+
+        info = JobInfo(rule="r", job_id="1", external_jobid="abc", cost_estimate=0.99)
+        assert Job.from_job_info(info).to_job_info().cost_estimate == 0.99
+
+
+class TestCostDisplay:
+    def test_per_job_cost_shown(self) -> None:
+        job = JobInfo(rule="align", job_id="7", external_jobid="abc", cost_estimate=0.0123)
+        lines = make_remote_job_info(job)
+        assert any("est. cost: $0.0123" in line for line in lines)
+
+    def test_no_cost_line_when_absent(self) -> None:
+        job = JobInfo(rule="align", job_id="7", external_jobid="abc")
+        assert not any("est. cost:" in line for line in make_remote_job_info(job))
+
+    def test_header_shows_workflow_cost(self) -> None:
+        from io import StringIO
+        from pathlib import Path
+
+        from rich.console import Console
+
+        from snakesee.models import WorkflowProgress
+        from snakesee.models import WorkflowStatus
+        from snakesee.tui.renderables import make_header
+
+        progress = WorkflowProgress(
+            workflow_dir=Path("/wf"),
+            status=WorkflowStatus.RUNNING,
+            total_jobs=3,
+            completed_jobs=2,
+            total_cost_estimate=0.42,
+        )
+        buf = StringIO()
+        Console(file=buf, width=200).print(
+            make_header(progress, "/wf", paused=False, event_reader=None)
+        )
+        out = buf.getvalue()
+        assert "Cost:" in out and "$0.42" in out and "(est)" in out

--- a/tests/test_remote_cost.py
+++ b/tests/test_remote_cost.py
@@ -54,6 +54,30 @@ class TestCostPlumbing:
             )
         assert reg.total_cost_estimate() == pytest.approx(0.15)
 
+    def test_cost_by_rule_groups_and_sums(self) -> None:
+        reg = JobRegistry()
+        for jid, rule, cost in ((1, "align", 0.10), (2, "align", 0.05), (3, "sort", 0.20)):
+            reg.apply_event(
+                SnakeseeEvent(
+                    event_type=EventType.JOB_FINISHED,
+                    timestamp=1.0,
+                    job_id=jid,
+                    rule_name=rule,
+                    cost_estimate=cost,
+                    stopped_at=1.0,
+                )
+            )
+        by_rule = reg.cost_by_rule()
+        assert by_rule["align"] == pytest.approx(0.15)
+        assert by_rule["sort"] == pytest.approx(0.20)
+
+    def test_cost_by_rule_empty_without_cost(self) -> None:
+        reg = JobRegistry()
+        reg.apply_event(
+            SnakeseeEvent(event_type=EventType.JOB_FINISHED, timestamp=1.0, job_id=1, rule_name="r")
+        )
+        assert reg.cost_by_rule() == {}
+
     def test_total_cost_none_when_no_estimates(self) -> None:
         reg = JobRegistry()
         reg.apply_event(

--- a/tests/test_remote_queued.py
+++ b/tests/test_remote_queued.py
@@ -198,7 +198,7 @@ class TestDataSourceQueuedRouting:
         result = ds.apply_events_to_progress(
             base, [_event(EventType.JOB_STARTED, timestamp=150.0, job_id=7, started_at=142.0)]
         )
-        assert result.queued_jobs_list == []
+        assert result.queued_jobs_list == ()
         assert [j.job_id for j in result.running_jobs] == ["7"]
 
     def test_running_jobinfo_uses_true_started_at(


### PR DESCRIPTION
Builds on #73. Estimated cost display for remote jobs.

- Per-job cost in the job detail; per-rule cost in Rule Statistics; a workflow total in the header.
- Columns/indicators appear only when cost data is present, so non-remote runs are unaffected.
- An estimate (list/market price) produced by the executor, not a billed amount.

Stacked on #73; review/merge after it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cost estimation: jobs/events may include estimated USD costs; UI shows per-job and per-rule Cost columns and an aggregated workflow estimate (prefixed with ~ and marked “(est)”); costs formatted for readability.

* **Refactor**
  * Immutable snapshots for workflow/job collections to improve stability; cost totals normalized (non-finite values treated as absent).

* **Tests**
  * Added coverage for formatting, aggregation, per-rule totals, UI column behavior, and cost plumbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->