### PR TITLE
feat: surface termination source provenance in the job detail

### DIFF
--- a/snakesee/remote_termination.py
+++ b/snakesee/remote_termination.py
@@ -53,6 +53,31 @@ _CATEGORY_LABELS: Final[dict[str, str]] = {
     TERM_IMAGE_PULL: "image pull failed",
 }
 
+# Friendly labels for known sources — only the values the AWS Batch executor's
+# classifier actually emits today. Anything else (including contract-reserved
+# values like "eventbridge" and "executor_heuristic") falls back to the raw
+# string, the same forward-compat pattern the category labels use.
+_SOURCE_LABELS: Final[dict[str, str]] = {
+    SOURCE_AWS_INSTANCE_STATE: "EC2 instance state",
+    SOURCE_STATUS_REASON: "status-reason text",
+}
+
+
+def format_termination_source(source: str | None) -> str | None:
+    """Render the provenance of a termination classification as a "via ..." phrase.
+
+    Args:
+        source: The classification provenance (a SOURCE_* value, or a
+            forward-compat string). None or empty yields no phrase, so a
+            missing source can't render a dangling "via ".
+
+    Returns:
+        A "via <source label>" string, or None when there is no source to attribute.
+    """
+    if not source:
+        return None
+    return f"via {_SOURCE_LABELS.get(source, source.replace('_', ' '))}"
+
 
 def format_termination_marker(category: str | None, confidence: str | None) -> str | None:
     """Render a one-line termination marker, phrased by confidence.

--- a/snakesee/tui/renderables.py
+++ b/snakesee/tui/renderables.py
@@ -84,16 +84,27 @@ def make_remote_job_info(job: "JobInfo") -> list[Text]:
     # Prefer the executor's structured termination classification (rendered with
     # confidence). Fall back to snakesee's own low-confidence string heuristic only
     # when no structured category arrived (e.g. an older executor).
+    from snakesee.remote_termination import SOURCE_STATUS_REASON
     from snakesee.remote_termination import format_termination_marker
+    from snakesee.remote_termination import format_termination_source
 
     marker = format_termination_marker(job.termination_category, job.termination_confidence)
+    # Provenance only ever annotates a rendered marker: a source arriving with
+    # no usable category (no marker) has nothing to attribute and is dropped.
+    source = format_termination_source(job.termination_source) if marker is not None else None
     if job.termination_category is None and job.status_reason:
         from snakesee.remote_links import is_spot_interruption
 
         if is_spot_interruption(job.status_reason):
             marker = "possibly spot interrupted"
+            # The reader-side heuristic inspects the same field as the
+            # executor's status_reason source, so it carries the same label.
+            source = format_termination_source(SOURCE_STATUS_REASON)
     if marker is not None:
-        lines.append(Text(f"  {marker}"))
+        marker_line = Text(f"  {marker}")
+        if source is not None:
+            marker_line.append(f" ({source})", style="dim")
+        lines.append(marker_line)
 
     if job.status_reason:
         lines.append(Text(f"  reason: {job.status_reason}"))

--- a/snakesee/tui/renderables.py
+++ b/snakesee/tui/renderables.py
@@ -39,13 +39,17 @@ def format_cost(usd: float) -> str:
     return f"${usd:.4f}" if usd < 1 else f"${usd:,.2f}"
 
 
-def make_remote_job_info(job: "JobInfo") -> list[str]:
+def make_remote_job_info(job: "JobInfo") -> list[Text]:
     """Build display lines describing a remote job's external identifier and links.
 
     For a job that ran on a remote executor (e.g. AWS Batch), this surfaces the
     external job id and, when enough information is available, deep links to the
     AWS console and CloudWatch logs. It degrades gracefully: a bare job id with
     no region yields just the id line; a local job yields no lines at all.
+
+    Lines are Rich ``Text`` rather than ``str`` so styling (e.g. the dimmed
+    termination-source parenthetical) survives the job-detail ``RichLog``,
+    which deliberately disables markup to avoid misrendering log content.
 
     Args:
         job: The job to describe.
@@ -60,22 +64,22 @@ def make_remote_job_info(job: "JobInfo") -> list[str]:
     from snakesee.remote_links import cloudwatch_url
 
     label = job.executor or "remote"
-    lines = [f"{label} job: {job.external_jobid}"]
+    lines = [Text(f"{label} job: {job.external_jobid}")]
 
     if job.queue is not None:
-        lines.append(f"  queue:   {job.queue}")
+        lines.append(Text(f"  queue:   {job.queue}"))
 
     # Queue wait is distinct from run time: it's how long the job waited for a node.
     queue_wait = job.queue_wait
     if queue_wait is not None:
-        lines.append(f"  queued for: {format_duration(queue_wait)}")
+        lines.append(Text(f"  queued for: {format_duration(queue_wait)}"))
 
     # Attempt > 1 means the job was retried/preempted; worth surfacing.
     if job.attempt is not None and job.attempt > 1:
-        lines.append(f"  attempt: {job.attempt}")
+        lines.append(Text(f"  attempt: {job.attempt}"))
 
     if job.exit_code is not None:
-        lines.append(f"  exit code: {job.exit_code}")
+        lines.append(Text(f"  exit code: {job.exit_code}"))
 
     # Prefer the executor's structured termination classification (rendered with
     # confidence). Fall back to snakesee's own low-confidence string heuristic only
@@ -89,21 +93,21 @@ def make_remote_job_info(job: "JobInfo") -> list[str]:
         if is_spot_interruption(job.status_reason):
             marker = "possibly spot interrupted"
     if marker is not None:
-        lines.append(f"  {marker}")
+        lines.append(Text(f"  {marker}"))
 
     if job.status_reason:
-        lines.append(f"  reason: {job.status_reason}")
+        lines.append(Text(f"  reason: {job.status_reason}"))
 
     if job.cost_estimate is not None:
-        lines.append(f"  est. cost: {format_cost(job.cost_estimate)}")
+        lines.append(Text(f"  est. cost: {format_cost(job.cost_estimate)}"))
 
     console = batch_console_url(job.external_jobid, region=job.region)
     if console is not None:
-        lines.append(f"  console: {console}")
+        lines.append(Text(f"  console: {console}"))
 
     logs = cloudwatch_url(job.log_stream, region=job.region)
     if logs is not None:
-        lines.append(f"  logs:    {logs}")
+        lines.append(Text(f"  logs:    {logs}"))
 
     return lines
 

--- a/snakesee/tui/screens.py
+++ b/snakesee/tui/screens.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import ClassVar
 
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.binding import BindingType
@@ -88,16 +89,18 @@ class JobLogScreen(ModalScreen[None]):
         self,
         log_path: Path | None,
         lines: list[str],
-        header_lines: list[str] | None = None,
+        header_lines: list[Text] | None = None,
     ) -> None:
         """Initialize with the log path (shown as the border title) and tail lines.
 
         Args:
             log_path: Path to the job's log file, or None if unknown.
             lines: Tail lines (most recent at end) to render in the RichLog.
-            header_lines: Optional lines rendered above the log (e.g. a remote
-                job's external id and console/CloudWatch links). For a remote job
-                with no local log file, these may be the only content.
+            header_lines: Optional styled lines rendered above the log (e.g. a
+                remote job's external id and console/CloudWatch links). Rich
+                ``Text`` rather than ``str`` so styles survive the markup-less
+                RichLog. For a remote job with no local log file, these may be
+                the only content.
         """
         super().__init__()
         self._log_path = log_path
@@ -124,9 +127,9 @@ class JobLogScreen(ModalScreen[None]):
     def on_mount(self) -> None:
         """Write the optional header and captured tail lines into the RichLog widget."""
         log = self.query_one("#job-log", RichLog)
-        for line in self._header_lines:
-            log.write(line)
+        for header_line in self._header_lines:
+            log.write(header_line)
         if self._header_lines and self._lines:
             log.write("")  # blank separator between the remote header and the log tail
-        for line in self._lines:
-            log.write(line)
+        for tail_line in self._lines:
+            log.write(tail_line)

--- a/tests/test_app_screens.py
+++ b/tests/test_app_screens.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from rich.text import Text
+
 from snakesee.tui.app import SnakeseeApp
 from snakesee.tui.screens import EasterEggScreen
 from snakesee.tui.screens import HelpScreen
@@ -99,7 +101,7 @@ async def test_job_log_screen_renders_remote_header(tmp_path: Path) -> None:
     """A remote job with no local log shows only its header lines, titled 'remote job'."""
     from textual.widgets import RichLog
 
-    header = ["aws-batch job: abc123", "  console: https://example"]
+    header = [Text("aws-batch job: abc123"), Text("  console: https://example")]
 
     app = SnakeseeApp(workflow_dir=tmp_path)
     async with app.run_test() as pilot:
@@ -117,7 +119,7 @@ async def test_job_log_screen_header_plus_log_has_separator(tmp_path: Path) -> N
     """Header lines and log tail are separated by a blank line when both present."""
     from textual.widgets import RichLog
 
-    header = ["aws-batch job: abc123"]
+    header = [Text("aws-batch job: abc123")]
     lines = ["log line one", "log line two"]
 
     app = SnakeseeApp(workflow_dir=tmp_path)

--- a/tests/test_remote_cost.py
+++ b/tests/test_remote_cost.py
@@ -96,11 +96,11 @@ class TestCostDisplay:
     def test_per_job_cost_shown(self) -> None:
         job = JobInfo(rule="align", job_id="7", external_jobid="abc", cost_estimate=0.0123)
         lines = make_remote_job_info(job)
-        assert any("est. cost: $0.0123" in line for line in lines)
+        assert any("est. cost: $0.0123" in line.plain for line in lines)
 
     def test_no_cost_line_when_absent(self) -> None:
         job = JobInfo(rule="align", job_id="7", external_jobid="abc")
-        assert not any("est. cost:" in line for line in make_remote_job_info(job))
+        assert not any("cost" in line.plain for line in make_remote_job_info(job))
 
     def test_header_shows_workflow_cost(self) -> None:
         from io import StringIO

--- a/tests/test_remote_observability.py
+++ b/tests/test_remote_observability.py
@@ -139,20 +139,20 @@ class TestObservabilityDisplay:
             status_reason="Spot interruption: capacity reclaimed",
         )
         lines = make_remote_job_info(job)
-        assert any("attempt: 2" in line for line in lines)
-        assert any("exit code: 137" in line for line in lines)
-        assert any("spot interrupted" in line for line in lines)
-        assert any("reason:" in line and "capacity reclaimed" in line for line in lines)
+        assert any("attempt: 2" in line.plain for line in lines)
+        assert any("exit code: 137" in line.plain for line in lines)
+        assert any("spot interrupted" in line.plain for line in lines)
+        assert any("reason:" in line.plain and "capacity reclaimed" in line.plain for line in lines)
 
     def test_first_attempt_not_shown(self) -> None:
         # attempt == 1 is the normal case; don't clutter the detail with it.
         job = JobInfo(rule="align", job_id="7", external_jobid="abc", attempt=1)
         lines = make_remote_job_info(job)
-        assert not any("attempt:" in line for line in lines)
+        assert not any("attempt:" in line.plain for line in lines)
 
     def test_clean_success_has_no_reason_or_spot(self) -> None:
         job = JobInfo(rule="align", job_id="7", external_jobid="abc", exit_code=0)
         lines = make_remote_job_info(job)
-        assert any("exit code: 0" in line for line in lines)
-        assert not any("spot interrupted" in line for line in lines)
-        assert not any("reason:" in line for line in lines)
+        assert any("exit code: 0" in line.plain for line in lines)
+        assert not any("spot interrupted" in line.plain for line in lines)
+        assert not any("reason:" in line.plain for line in lines)

--- a/tests/test_remote_surface.py
+++ b/tests/test_remote_surface.py
@@ -23,14 +23,14 @@ class TestMakeRemoteJobInfo:
         """A bare external id with no region shows the id but no console link."""
         job = JobInfo(rule="align", job_id="1", external_jobid="abc123", executor="aws-batch")
         lines = make_remote_job_info(job)
-        assert lines == ["aws-batch job: abc123"]
+        assert [line.plain for line in lines] == ["aws-batch job: abc123"]
 
     def test_arn_yields_console_link(self) -> None:
         """An ARN carries its region, so a console link can be built."""
         job = JobInfo(rule="align", job_id="1", external_jobid=ARN, executor="aws-batch")
         lines = make_remote_job_info(job)
-        assert lines[0] == f"aws-batch job: {ARN}"
-        assert any("console:" in line and "region=us-east-1" in line for line in lines)
+        assert lines[0].plain == f"aws-batch job: {ARN}"
+        assert any("console:" in line.plain and "region=us-east-1" in line.plain for line in lines)
 
     def test_region_and_log_stream_yield_both_links(self) -> None:
         """With region + log stream, both console and CloudWatch links appear."""
@@ -43,13 +43,13 @@ class TestMakeRemoteJobInfo:
             log_stream="JobDef/default/abc",
         )
         lines = make_remote_job_info(job)
-        assert any("console:" in line for line in lines)
-        assert any("logs:" in line and "cloudwatch" in line for line in lines)
+        assert any("console:" in line.plain for line in lines)
+        assert any("logs:" in line.plain and "cloudwatch" in line.plain for line in lines)
 
     def test_falls_back_to_remote_label_without_executor(self) -> None:
         """When the executor name is unknown, a neutral 'remote' label is used."""
         job = JobInfo(rule="align", job_id="1", external_jobid="abc123")
-        assert make_remote_job_info(job)[0] == "remote job: abc123"
+        assert make_remote_job_info(job)[0].plain == "remote job: abc123"
 
     def test_shows_queue_and_queue_wait(self) -> None:
         """Queue name and queue wait (start_time - queued_at) are surfaced."""
@@ -63,8 +63,8 @@ class TestMakeRemoteJobInfo:
             start_time=142.0,  # 42s queue wait
         )
         lines = make_remote_job_info(job)
-        assert any("queue:" in line and "graviton-spot" in line for line in lines)
-        assert any("queued for:" in line for line in lines)
+        assert any("queue:" in line.plain and "graviton-spot" in line.plain for line in lines)
+        assert any("queued for:" in line.plain for line in lines)
 
 
 class TestIncompleteJobCarriesExternalId:
@@ -90,4 +90,4 @@ class TestIncompleteJobCarriesExternalId:
         )
         assert job.external_jobid == ARN
         # And it round-trips into display lines.
-        assert make_remote_job_info(job)[0].endswith(ARN)
+        assert make_remote_job_info(job)[0].plain.endswith(ARN)

--- a/tests/test_remote_termination.py
+++ b/tests/test_remote_termination.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from rich.text import Text
+
 from snakesee import remote_termination
 from snakesee.remote_termination import CONFIDENCE_HIGH
 from snakesee.remote_termination import CONFIDENCE_LOW
 from snakesee.remote_termination import SOURCE_AWS_INSTANCE_STATE
+from snakesee.remote_termination import SOURCE_EVENTBRIDGE
 from snakesee.remote_termination import SOURCE_STATUS_REASON
 from snakesee.remote_termination import TERM_OOM
 from snakesee.remote_termination import TERM_SPOT
@@ -223,3 +226,126 @@ class TestFormatTerminationSource:
     def test_empty_source_yields_none(self) -> None:
         # An empty string must not render a dangling "via ".
         assert format_termination_source("") is None
+
+
+class TestSourceDisplay:
+    """The termination source renders as a dimmed parenthetical on the marker line."""
+
+    @staticmethod
+    def _marker_line(lines: list[Text]) -> Text:
+        marker = next((line for line in lines if "spot interrupted" in line.plain), None)
+        assert marker is not None, f"no marker line in {[line.plain for line in lines]}"
+        return marker
+
+    def test_structured_source_rendered_dimmed(self) -> None:
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            termination_category=TERM_SPOT,
+            termination_source=SOURCE_AWS_INSTANCE_STATE,
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        marker = self._marker_line(make_remote_job_info(job))
+        assert marker.plain == "  ⚠ spot interrupted (via EC2 instance state)"
+        # Exactly the parenthetical (with its leading space) is dimmed.
+        dim_spans = [span for span in marker.spans if span.style == "dim"]
+        assert len(dim_spans) == 1
+        assert marker.plain[dim_spans[0].start : dim_spans[0].end] == " (via EC2 instance state)"
+
+    def test_unknown_source_renders_raw_fallback(self) -> None:
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            termination_category=TERM_SPOT,
+            termination_source=SOURCE_EVENTBRIDGE,  # contract-reserved, no friendly label
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        marker = self._marker_line(make_remote_job_info(job))
+        assert marker.plain == "  ⚠ spot interrupted (via eventbridge)"
+
+    def test_no_source_no_parenthetical(self) -> None:
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            termination_category=TERM_SPOT,
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        marker = self._marker_line(make_remote_job_info(job))
+        assert marker.plain == "  ⚠ spot interrupted"
+        assert not marker.spans
+
+    def test_orphaned_source_not_rendered(self) -> None:
+        # A source with no usable category (no marker) is provenance with
+        # nothing to attribute — deliberately dropped (spec §2).
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            termination_source=SOURCE_AWS_INSTANCE_STATE,
+        )
+        lines = make_remote_job_info(job)
+        assert not any("via" in line.plain for line in lines)
+
+    def test_unknown_category_orphans_source(self) -> None:
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            termination_category=TERM_UNKNOWN,
+            termination_source=SOURCE_AWS_INSTANCE_STATE,
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        lines = make_remote_job_info(job)
+        assert not any("via" in line.plain for line in lines)
+
+    def test_reader_fallback_labeled_status_reason_text(self) -> None:
+        # snakesee's own string heuristic inspects status_reason, so it carries
+        # the same label as the executor's status_reason source — by design.
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            status_reason="Spot interruption: capacity reclaimed",
+        )
+        marker = self._marker_line(make_remote_job_info(job))
+        assert marker.plain == "  possibly spot interrupted (via status-reason text)"
+        assert any(span.style == "dim" for span in marker.spans)
+
+    def test_structured_source_wins_over_fallback_eligible_reason(self) -> None:
+        # Both a structured classification AND a spot-matching status_reason:
+        # the structured source labels the marker; the heuristic never runs.
+        from snakesee.models import JobInfo
+        from snakesee.tui.renderables import make_remote_job_info
+
+        job = JobInfo(
+            rule="align",
+            job_id="7",
+            external_jobid="abc",
+            status_reason="Spot interruption: capacity reclaimed",
+            termination_category=TERM_SPOT,
+            termination_source=SOURCE_AWS_INSTANCE_STATE,
+            termination_confidence=CONFIDENCE_HIGH,
+        )
+        marker = self._marker_line(make_remote_job_info(job))
+        assert marker.plain == "  ⚠ spot interrupted (via EC2 instance state)"

--- a/tests/test_remote_termination.py
+++ b/tests/test_remote_termination.py
@@ -107,8 +107,8 @@ class TestTerminationEndToEnd:
             termination_confidence=CONFIDENCE_HIGH,
         )
         lines = make_remote_job_info(job)
-        assert any("⚠ spot interrupted" in line for line in lines)
-        assert not any("possibly" in line for line in lines)
+        assert any("⚠ spot interrupted" in line.plain for line in lines)
+        assert not any("possibly" in line.plain for line in lines)
 
     def test_structured_suppresses_string_heuristic(self) -> None:
         # When a high-confidence classification AND a spot-matching status_reason
@@ -125,10 +125,10 @@ class TestTerminationEndToEnd:
             termination_confidence=CONFIDENCE_HIGH,
         )
         lines = make_remote_job_info(job)
-        markers = [line for line in lines if "spot interrupted" in line]
+        markers = [line for line in lines if "spot interrupted" in line.plain]
         assert len(markers) == 1
-        assert "⚠ spot interrupted" in markers[0]
-        assert "possibly" not in markers[0]
+        assert "⚠ spot interrupted" in markers[0].plain
+        assert "possibly" not in markers[0].plain
 
     def test_explicit_unknown_suppresses_string_heuristic(self) -> None:
         # An explicit TERM_UNKNOWN is still a structured classification: the executor
@@ -145,7 +145,7 @@ class TestTerminationEndToEnd:
             termination_confidence=CONFIDENCE_HIGH,
         )
         lines = make_remote_job_info(job)
-        assert not any("spot interrupted" in line for line in lines)
+        assert not any("spot interrupted" in line.plain for line in lines)
 
     def test_from_job_info_round_trip(self) -> None:
         from snakesee.models import JobInfo
@@ -180,7 +180,7 @@ class TestTerminationEndToEnd:
             status_reason="Spot interruption: capacity reclaimed",
         )
         lines = make_remote_job_info(job)
-        assert any("possibly spot interrupted" in line for line in lines)
+        assert any("possibly spot interrupted" in line.plain for line in lines)
 
     def test_plugin_adapter_passes_termination_through(self) -> None:
         # The plugin's reader-side event also carries the fields after JSON round trip.

--- a/tests/test_remote_termination.py
+++ b/tests/test_remote_termination.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from snakesee import remote_termination
 from snakesee.remote_termination import CONFIDENCE_HIGH
 from snakesee.remote_termination import CONFIDENCE_LOW
+from snakesee.remote_termination import SOURCE_AWS_INSTANCE_STATE
+from snakesee.remote_termination import SOURCE_STATUS_REASON
 from snakesee.remote_termination import TERM_OOM
 from snakesee.remote_termination import TERM_SPOT
 from snakesee.remote_termination import TERM_UNKNOWN
 from snakesee.remote_termination import format_termination_marker
+from snakesee.remote_termination import format_termination_source
 
 
 class TestContractValues:
@@ -197,3 +200,26 @@ class TestTerminationEndToEnd:
         assert event.termination_category == "spot"
         assert event.termination_source == "aws_instance_state"
         assert event.termination_confidence == "high"
+
+
+class TestFormatTerminationSource:
+    """format_termination_source renders provenance as a 'via ...' phrase."""
+
+    def test_aws_instance_state_label(self) -> None:
+        assert format_termination_source(SOURCE_AWS_INSTANCE_STATE) == "via EC2 instance state"
+
+    def test_status_reason_label(self) -> None:
+        assert format_termination_source(SOURCE_STATUS_REASON) == "via status-reason text"
+
+    def test_unknown_source_falls_back_to_raw(self) -> None:
+        # Contract-reserved but unemitted values render via the raw fallback
+        # (forward-compat with executors that send new sources).
+        assert format_termination_source("executor_heuristic") == "via executor heuristic"
+        assert format_termination_source("eventbridge") == "via eventbridge"
+
+    def test_none_source_yields_none(self) -> None:
+        assert format_termination_source(None) is None
+
+    def test_empty_source_yields_none(self) -> None:
+        # An empty string must not render a dangling "via ".
+        assert format_termination_source("") is None


### PR DESCRIPTION
Closes #77.

## Summary

The remote-job-state contract carries a provenance-tagged termination classification (`termination_category` / `termination_source` / `termination_confidence`), but the job detail screen only rendered the category, phrased by confidence. The user couldn't see *why* a classification was high- vs low-confidence. The marker line now appends a dimmed parenthetical naming the provenance:

```
  ⚠ spot interrupted (via EC2 instance state)
  possibly spot interrupted (via status-reason text)
```

## Changes (suggested reading order)

1. `feat: add provenance labels for termination sources` — `_SOURCE_LABELS` + `format_termination_source()` in `remote_termination.py`, mirroring the category-label pattern. Only the two sources the AWS Batch executor actually emits get friendly labels (`aws_instance_state` → "EC2 instance state", `status_reason` → "status-reason text"); anything else — including the contract-reserved `eventbridge` / `executor_heuristic` — renders via the raw `replace("_", " ")` fallback. Falsy sources yield `None` so an empty string can't render a dangling "via ".
2. `refactor: return styled Text lines from make_remote_job_info` — mechanical flip to `list[Text]` so the style can travel as spans through the job-detail `RichLog`, which deliberately has `markup=False`. `JobLogScreen.header_lines` widens to match; the log-tail `lines` stays `list[str]`. Accepted tradeoff: `Text` input bypasses the RichLog's `ReprHighlighter`, so header lines lose URL/number auto-highlighting in favor of controlled styling. Output strings are `.plain`-identical; 25 test assertions converted to compare via `.plain`.
3. `feat: surface termination source provenance in the job detail` — the rendering itself. Provenance only ever annotates a rendered marker: a `termination_source` arriving with no usable category (absent or `unknown`) is dropped — provenance with nothing to attribute is noise. snakesee's own reader-side spot heuristic labels itself `format_termination_source(SOURCE_STATUS_REASON)` — deliberately the same label as the executor's `status_reason` source, since both are low-confidence string matches on the same field, and single-sourcing the label keeps them from drifting apart.

## Test Plan

- [x] 7 new `TestSourceDisplay` tests: dim-span boundaries (exactly the parenthetical is dimmed), raw fallback for unlabeled sources, no source → no parenthetical and zero spans, both orphaned-source paths, reader-fallback labeling, and structured-source precedence over a fallback-eligible `status_reason`
- [x] 5 new `TestFormatTerminationSource` unit tests (labels, fallback, `None`, empty string)
- [x] Full suite green: 1145 passed, mypy strict clean, ruff format/lint clean
- [x] Visual sanity check: rendered `Text` carries `Span(20, 45, 'dim')` over `(via EC2 instance state)`

Stacked on `nh_remote-cost` (top of the remote-executor stack: `nh_remote-core` → `nh_remote-observability` → `nh_remote-cost`); merge those first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forward-compatible termination source rendering with friendly labels and graceful fallbacks for remote job termination provenance.

* **Style**
  * Remote job detail lines now preserve rich styling in the terminal UI, improving readability (dimmed provenance, styled status/details).

* **Tests**
  * Expanded and updated tests to cover styled renderables and termination-source display, including edge cases and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->