### PR TITLE
fix: snakesee watch crash when refresh rate differs from reactive default (#80)

### DIFF
--- a/snakesee/tui/app.py
+++ b/snakesee/tui/app.py
@@ -514,7 +514,13 @@ class SnakeseeApp(App[None]):
         # Resolve the workflow path once; the header truncates it per frame, so the
         # per-render cost stays a string slice rather than a filesystem resolve().
         self._resolved_workflow_dir = str(workflow_dir.resolve())
-        self.refresh_rate = refresh_rate
+        # Seed the reactive without firing watch_refresh_rate. A plain assignment would
+        # invoke the watcher (whenever refresh_rate differs from the reactive default),
+        # which calls set_interval() before run() has started the event loop, raising
+        # "RuntimeError: no running event loop". on_mount starts the timer once the loop
+        # is running. The ignore works around Textual's stubs typing class-level reactive
+        # access as the value type (float) rather than Reactive[float].
+        self.set_reactive(SnakeseeApp.refresh_rate, refresh_rate)  # type: ignore[arg-type]
 
     def compose(self) -> ComposeResult:
         """Compose the widget tree (header / progress / six tables / summary / footer)."""
@@ -548,10 +554,8 @@ class SnakeseeApp(App[None]):
         self.query_one("#incomplete", DataTable).add_columns("Output File")
         self.query_one("#stats", DataTable).add_columns("Rule", "Thr", "Count", "Avg", "Std Dev")
         self._refresh_panels()
-        # __init__ already triggered watch_refresh_rate which started a timer; stop it
-        # before mounting our own so we don't end up with two interval callbacks racing.
-        if self._refresh_timer is not None:
-            self._refresh_timer.stop()
+        # Start the polling timer now that the event loop is running. __init__ seeds
+        # refresh_rate via set_reactive (no watcher), so this is the only timer created.
         self._refresh_timer = self.set_interval(self.refresh_rate, self._refresh_panels)
         self.add_class(f"-{self.layout_mode.value}")
 

--- a/tests/test_app_refresh_logs.py
+++ b/tests/test_app_refresh_logs.py
@@ -54,6 +54,23 @@ async def test_refresh_rate_clamped_max(snakemake_dir: Path, tmp_path: Path) -> 
         await pilot.press("q")
 
 
+def test_construct_with_non_default_refresh_rate_no_event_loop(
+    snakemake_dir: Path, tmp_path: Path
+) -> None:
+    """Constructing the app with a non-default refresh rate must not require a running loop.
+
+    The CLI builds ``SnakeseeApp`` synchronously (before ``run()`` starts the event
+    loop) and passes ``refresh`` defaulting to 2.0, which differs from the
+    ``refresh_rate`` reactive's default. A premature reactive watcher that called
+    ``set_interval`` here would raise ``RuntimeError: no running event loop``. This is
+    deliberately a synchronous (non-async) test so no event loop is running, matching
+    the real CLI path.
+    """
+    assert DEFAULT_REFRESH_RATE != 2.0, "test assumes 2.0 differs from the reactive default"
+    app = SnakeseeApp(workflow_dir=tmp_path, refresh_rate=2.0)
+    assert app.refresh_rate == pytest.approx(2.0)
+
+
 async def test_refresh_rate_reset(snakemake_dir: Path, tmp_path: Path) -> None:
     """Pressing '0' resets refresh_rate to DEFAULT_REFRESH_RATE."""
     app = SnakeseeApp(workflow_dir=tmp_path, refresh_rate=15.0)


### PR DESCRIPTION
## Summary

`snakesee watch` crashed on startup with `RuntimeError: no running event loop` (plus `RuntimeWarning: coroutine 'Timer._run_timer' was never awaited`), reported in #80. `snakesee status` was unaffected because it does not start the Textual app.

## Root cause

`refresh_rate` is a reactive whose default is `DEFAULT_REFRESH_RATE` (1.0). The CLI `watch` command defaults `refresh` to 2.0 and passes it into `SnakeseeApp`. In `__init__`, `self.refresh_rate = refresh_rate` changed the value (2.0 ≠ 1.0), which fired `watch_refresh_rate`. That watcher calls `self.set_interval(...)`, but `__init__` runs synchronously before `run()` starts the event loop, so Textual's `Timer._start()` → `create_task()` → `get_running_loop()` raised.

Any real `snakesee watch` invocation without an explicit `--refresh` hit this; `snakesee watch --refresh 1.0` happened to avoid it.

## Why it was missed

The bug only triggers when the constructed value differs from the reactive default. The demo runner and the test suite construct the app either with the default rate (no value change, watcher never fires) or inside `async def` tests where a running event loop already exists — so the premature `set_interval` silently succeeded. The CLI's synchronous construction is the only path with no loop yet.

## Fix

Seed the reactive in `__init__` via `set_reactive()`, which sets the value without invoking watchers. `on_mount` (already running inside the event loop) creates the single polling timer. Runtime rate changes via `+`/`-`/`0`/`G` keys still restart the timer through `watch_refresh_rate` as before. The now-dead "stop the duplicate timer" block in `on_mount` is removed.

## Testing (TDD)

Added `test_construct_with_non_default_refresh_rate_no_event_loop`, a deliberately **synchronous** (non-async) test so no event loop is running — matching the real CLI path. It fails on `main` with the exact reported `RuntimeError` and passes with this fix. The existing async rate-change tests continue to pass, confirming `watch_refresh_rate` still works once the loop is up.

`uv run poe check-all` passes (format, lint, mypy, 1119+ tests).

Fixes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed app initialization issue where custom refresh rate settings could cause premature timer creation before the event loop started, ensuring reliable app initialization with custom refresh rates.

* **Tests**
  * Added test coverage verifying app initialization with custom refresh rates functions correctly without a running event loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->