### PR TITLE
fix: preserve logger events delivered after handler close()

### DIFF
--- a/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/writer.py
+++ b/snakemake-logger-plugin-snakesee/src/snakemake_logger_plugin_snakesee/writer.py
@@ -17,7 +17,9 @@ class EventWriter:
 
     Thread safety is critical because Snakemake dispatches log events via a
     ``QueueListener`` background thread, while handler ``close()`` may be
-    called from the main thread during cleanup.
+    called from the main thread during cleanup. Because Snakemake closes the
+    handler *before* it drains that queue, ``write()`` tolerates events that
+    arrive after ``close()`` by reopening the file rather than dropping them.
 
     Attributes:
         path: Path to the event file.
@@ -74,12 +76,23 @@ class EventWriter:
 
         Events are buffered and flushed when the buffer is full.
 
+        Snakemake closes file-writing handlers (``cleanup_logfile()``) *before*
+        it drains the logging ``QueueListener`` (``stop()``), so events can be
+        delivered here after ``close()`` has run. Such a late event re-activates
+        the writer — ``_flush_locked`` reopens the file in append mode via
+        ``_ensure_open`` — rather than being dropped. Dropping them silently
+        loses the tail of the event stream (job completions, final progress)
+        whenever the listener lags under load, e.g. on a busy CI runner. The
+        next ``close()`` (snakemake's or our ``atexit`` hook) flushes and
+        releases the handle again.
+
         Args:
             event: The event to write.
         """
         with self._lock:
-            if self._closed:
-                return
+            # Re-activate if a previous close() ran; the trailing close()
+            # flushes any buffered late events and releases the file handle.
+            self._closed = False
             self._buffer.append(event)
             if len(self._buffer) >= self.buffer_size:
                 self._flush_locked()

--- a/snakemake-logger-plugin-snakesee/tests/test_writer.py
+++ b/snakemake-logger-plugin-snakesee/tests/test_writer.py
@@ -173,12 +173,13 @@ class TestEventWriter:
         assert parsed.event_type == EventType.WORKFLOW_STARTED
         assert parsed.timestamp == 3.0
 
-    def test_concurrent_write_and_close(self, tmp_path: Path) -> None:
-        """Test that close() during concurrent writes doesn't lose events or raise.
+    def test_concurrent_write_and_close_loses_nothing(self, tmp_path: Path) -> None:
+        """close() during concurrent writes must not lose events or raise.
 
-        Simulates the race condition caused by Snakemake's cleanup calling
-        handler.close() from the main thread while the QueueListener
-        background thread is still delivering events via emit()/write().
+        Reproduces Snakemake's race: cleanup calls handler.close() from the
+        main thread while the QueueListener background thread is still
+        delivering events via emit()/write(). Every event must reach the file
+        regardless of how the close() interleaves with the concurrent writes.
         """
         event_file = tmp_path / "events.jsonl"
         writer = EventWriter(event_file)
@@ -206,26 +207,92 @@ class TestEventWriter:
         # Close from main thread while writer thread is active
         writer.close()
         t.join()
+        # Final close, mirroring snakemake's post-drain / atexit cleanup.
+        writer.close()
 
-        # The initial event plus some subset of the concurrent writes
-        # must be on disk; events arriving after close() are silently
-        # dropped (no crash).
+        # Nothing may be dropped: the initial event plus every concurrent write.
         lines = event_file.read_text().strip().split("\n")
-        assert len(lines) >= 1
-        assert len(lines) <= num_events + 1
+        assert len(lines) == num_events + 1
 
-    def test_write_after_close_is_silent(self, tmp_path: Path) -> None:
-        """Test that write() after close() is silently ignored."""
+    def test_write_after_close_reopens_and_appends(self, tmp_path: Path) -> None:
+        """write() after close() reopens the file and appends (no loss, no raise).
+
+        See ``test_events_delivered_after_close_are_not_lost`` for the
+        snakemake lifecycle this guards against.
+        """
         event_file = tmp_path / "events.jsonl"
         writer = EventWriter(event_file)
         writer.write(SnakeseeEvent(event_type=EventType.WORKFLOW_STARTED, timestamp=1.0))
         writer.close()
 
-        # Write after close should not raise
+        # Write after close must not raise and must not be dropped.
         writer.write(SnakeseeEvent(event_type=EventType.JOB_STARTED, timestamp=2.0, job_id=1))
+        writer.close()
 
         lines = event_file.read_text().strip().split("\n")
-        assert len(lines) == 1
+        assert len(lines) == 2
+
+    def test_events_delivered_after_close_are_not_lost(self, tmp_path: Path) -> None:
+        """Events delivered after close() must be written, not dropped.
+
+        Regression test for silent event loss under load. Snakemake closes
+        file-writing handlers (``cleanup_logfile()``) BEFORE it drains the
+        logging ``QueueListener`` (``stop()``). Every record still queued at
+        that moment is delivered to the handler — and therefore ``write()`` —
+        *after* ``close()`` has run. Those late events must still reach the
+        file; dropping them silently loses the tail of the event stream
+        (job completions, final progress) whenever the listener lags under
+        load, which is exactly what happens on a busy CI runner.
+        """
+        event_file = tmp_path / "events.jsonl"
+        writer = EventWriter(event_file)
+
+        writer.write(SnakeseeEvent(event_type=EventType.WORKFLOW_STARTED, timestamp=1.0))
+        writer.close()  # snakemake cleanup_logfile() closes us first
+
+        # snakemake's QueueListener.stop() now drains queued records to us
+        post_close = [
+            SnakeseeEvent(event_type=EventType.JOB_STARTED, timestamp=2.0, job_id=1),
+            SnakeseeEvent(event_type=EventType.JOB_FINISHED, timestamp=3.0, job_id=1),
+        ]
+        for event in post_close:
+            writer.write(event)
+        writer.close()
+
+        lines = event_file.read_text().strip().split("\n")
+        assert len(lines) == 3, f"expected 3 events, lost some: {lines}"
+        types = [SnakeseeEvent.from_json(line).event_type for line in lines]
+        assert types == [
+            EventType.WORKFLOW_STARTED,
+            EventType.JOB_STARTED,
+            EventType.JOB_FINISHED,
+        ]
+
+    def test_buffered_late_events_flush_on_trailing_close(self, tmp_path: Path) -> None:
+        """With buffer_size > 1, a post-close event must flush on the trailing close().
+
+        Guards the ``_closed`` reset in ``write()``. ``buffer_size`` is
+        configurable (``LogHandlerSettings.buffer_size``); when > 1 a late event
+        is buffered, not flushed immediately, so the reset is what lets the
+        trailing ``close()`` flush it instead of early-returning and dropping it.
+        The ``buffer_size=1`` cases above flush each write immediately and so
+        would still pass even if the reset were missing — this case would not.
+        """
+        event_file = tmp_path / "events.jsonl"
+        writer = EventWriter(event_file, buffer_size=3)
+
+        writer.write(SnakeseeEvent(event_type=EventType.WORKFLOW_STARTED, timestamp=1.0))
+        writer.close()  # flushes the buffered first event
+        assert len(event_file.read_text().strip().split("\n")) == 1
+
+        # Delivered after close() and buffered (buffer not yet full → not flushed).
+        writer.write(SnakeseeEvent(event_type=EventType.JOB_STARTED, timestamp=2.0, job_id=1))
+        assert len(event_file.read_text().strip().split("\n")) == 1
+
+        writer.close()  # trailing close() must flush the buffered late event
+        lines = event_file.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert SnakeseeEvent.from_json(lines[1]).event_type == EventType.JOB_STARTED
 
     def test_double_close(self, tmp_path: Path) -> None:
         """Test that close() can be called multiple times safely."""


### PR DESCRIPTION
## Summary

The snakesee logger plugin silently drops the tail of the event stream under load. Snakemake closes file-writing handlers (`cleanup_logfile()`) **before** it drains the logging `QueueListener` (`stop()`), so records still queued at cleanup are delivered to `EventWriter.write()` *after* `close()` ran — where an `if self._closed: return` guard threw them away. Under load (e.g. CI), the listener lags and a large backlog is lost: job completions and final progress never reach the event file.

This is also the root cause of the flaky Snakemake-9.x integration tests seen on #71 (`job_count < total_jobs` because the tail `job_started`/`job_finished` events were dropped).

## Fix

`write()` now tolerates post-close delivery: a late event re-activates the writer and reopens the file in append mode; the trailing `close()` (snakemake's cleanup or our `atexit` hook) flushes and releases the handle. The `_closed` reset matters for `buffer_size > 1` too — it ensures the trailing `close()` still flushes buffered late events rather than early-returning.

## Verification

End-to-end with a 120-job fan-out under injected per-event write latency (modelling a loaded CI runner):

- **Before:** 52/485 events written, **433 dropped**
- **After:** **485/485 written, 0 dropped**

Inverted the two writer tests that had codified the loss as intended behavior (`test_write_after_close_is_silent`, `test_concurrent_write_and_close`) and added a regression test asserting events delivered after `close()` survive (RED→GREEN against the fix). Full plugin suite: 59 passed; ruff check/format and mypy clean.

## Notes

- `--logger snakesee` is opt-in, so log-polling users are unaffected; this is a data-loss fix for anyone using the plugin to monitor large/wide workflows under load.
- No integration-harness change is needed: the drain completes inside snakemake's cleanup before the workflow process exits, so once events aren't dropped the integration assertions pass deterministically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented loss of log events delivered during shutdown—late-arriving events are now preserved and appended rather than dropped.
  * Ensures a final close reliably flushes any remaining buffered events.

* **Tests**
  * Strengthened regression tests to cover concurrent close/write interleavings and post-close event delivery.
  * Added tests for buffered late events to verify correct flush behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->