### PR TITLE
feat: actionable error when TUI dependencies are missing

### DIFF
--- a/snakesee/cli.py
+++ b/snakesee/cli.py
@@ -23,6 +23,46 @@ from snakesee.profile import load_profile
 
 logger = logging.getLogger(__name__)
 
+# Top-level module names of the optional TUI stack. These are declared as hard
+# dependencies in pyproject.toml, but a partial install (notably a conda/bioconda
+# package whose recipe omitted them) can leave them absent. They are imported
+# lazily so the non-interactive commands keep working without them; the TUI
+# commands surface an actionable error instead of a raw ModuleNotFoundError.
+_TUI_DEPENDENCY_MODULES = {"textual", "rich_pixels", "PIL"}
+
+
+def _is_missing_tui_dependency(error: ModuleNotFoundError) -> bool:
+    """Return True if the error is a missing TUI dependency (not an internal bug).
+
+    Args:
+        error: The ModuleNotFoundError to classify.
+
+    Returns:
+        True if the missing module is part of the optional TUI stack.
+    """
+    return (error.name or "").split(".", 1)[0] in _TUI_DEPENDENCY_MODULES
+
+
+def _exit_missing_tui_dependency(error: ModuleNotFoundError) -> NoReturn:
+    """Print an actionable message for a missing TUI dependency and exit.
+
+    Args:
+        error: The ModuleNotFoundError raised while importing the TUI stack.
+    """
+    console = Console(stderr=True)
+    console.print(
+        f"[red]Error:[/red] The snakesee TUI requires additional packages that "
+        f"are not installed (missing: {error.name})."
+    )
+    console.print(
+        "These ship with snakesee but may be absent in a partial conda/pixi install. "
+        "Install the TUI stack, e.g.:"
+    )
+    console.print("    pip install textual rich-pixels pillow")
+    console.print("or reinstall snakesee from PyPI:")
+    console.print("    pip install --force-reinstall snakesee")
+    sys.exit(1)
+
 
 def _validate_workflow_dir(workflow_dir: Path) -> Path:
     """
@@ -117,8 +157,13 @@ def watch(
     # Load profile if specified or auto-discover
     profile_path = profile or find_profile(workflow_dir)
 
-    from snakesee.tui import WorkflowMonitorTUI
-    from snakesee.tui.accessibility import ACCESSIBLE_CONFIG
+    try:
+        from snakesee.tui import WorkflowMonitorTUI
+        from snakesee.tui.accessibility import ACCESSIBLE_CONFIG
+    except ModuleNotFoundError as e:
+        if not _is_missing_tui_dependency(e):
+            raise
+        _exit_missing_tui_dependency(e)
 
     accessibility_config = ACCESSIBLE_CONFIG if colorblind else None
 
@@ -361,7 +406,12 @@ def demo(
                 CI and scripting.
         clean: Wipe all demo dirs in the cache and exit without launching anything.
     """
-    from snakesee.demo import run_demo
+    try:
+        from snakesee.demo import run_demo
+    except ModuleNotFoundError as e:
+        if not _is_missing_tui_dependency(e):
+            raise
+        _exit_missing_tui_dependency(e)
 
     rc = run_demo(
         cores=cores,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,17 @@
 """Tests for the CLI module."""
 
 import json
+import sys
 import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from snakesee.cli import _exit_missing_tui_dependency
+from snakesee.cli import _is_missing_tui_dependency
 from snakesee.cli import _validate_workflow_dir
+from snakesee.cli import demo
 from snakesee.cli import profile_export
 from snakesee.cli import profile_show
 from snakesee.cli import status
@@ -87,6 +91,94 @@ class TestWatch:
                 accessibility_config=ACCESSIBLE_CONFIG,
             )
             mock_instance.run.assert_called_once()
+
+
+def _block_textual_import(monkeypatch: pytest.MonkeyPatch, *prefixes: str) -> None:
+    """Make ``import textual`` fail as it would in a partial install.
+
+    Drops every cached ``textual`` module and marks the package as known-absent
+    (``sys.modules['textual'] = None``), then evicts the given snakesee module
+    prefixes so their lazy ``from textual ... import`` statements re-run and fail.
+    monkeypatch restores all of sys.modules after the test.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        prefixes: snakesee module prefixes whose cached entries must be evicted.
+    """
+    for name in [m for m in sys.modules if m == "textual" or m.startswith("textual.")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "textual", None)
+    for prefix in prefixes:
+        for name in [m for m in sys.modules if m.startswith(prefix)]:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+class TestMissingTuiDependency:
+    """Tests for graceful handling of a missing TUI dependency stack."""
+
+    def test_is_missing_tui_dependency_true_for_tui_modules(self) -> None:
+        """TUI stack modules (incl. submodules) are classified as TUI deps."""
+        for name in ("textual", "textual.app", "rich_pixels", "PIL", "PIL.Image"):
+            error = ModuleNotFoundError(f"No module named {name!r}", name=name)
+            assert _is_missing_tui_dependency(error), name
+
+    def test_is_missing_tui_dependency_false_for_other_modules(self) -> None:
+        """A non-TUI missing module is not classified as a TUI dep."""
+        error = ModuleNotFoundError("No module named 'snakesee.broken'", name="snakesee.broken")
+        assert not _is_missing_tui_dependency(error)
+
+    def test_is_missing_tui_dependency_handles_none_name(self) -> None:
+        """An error with no module name is not treated as a TUI dep."""
+        assert not _is_missing_tui_dependency(ModuleNotFoundError("nameless"))
+
+    def test_exit_emits_actionable_message_to_stderr(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The exit helper writes an install hint to stderr and exits non-zero."""
+        error = ModuleNotFoundError("No module named 'textual'", name="textual")
+        with pytest.raises(SystemExit) as exc_info:
+            _exit_missing_tui_dependency(error)
+        # mypy types the helper as NoReturn, so it flags the post-`with` body as
+        # unreachable; at runtime pytest.raises catches the SystemExit and we do reach here.
+        assert exc_info.value.code == 1  # type: ignore[unreachable]
+
+        captured = capsys.readouterr()
+        assert "textual" in captured.err
+        assert "pip install" in captured.err
+        # No traceback noise leaks to stdout.
+        assert captured.out == ""
+
+    def test_watch_reports_missing_textual(
+        self,
+        snakemake_dir: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """watch exits cleanly with an actionable message when textual is absent."""
+        _block_textual_import(monkeypatch, "snakesee.tui")
+
+        with pytest.raises(SystemExit) as exc_info:
+            watch(tmp_path)
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        assert "textual" in captured.err
+
+    def test_demo_reports_missing_textual(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """demo exits cleanly with an actionable message when textual is absent."""
+        _block_textual_import(monkeypatch, "snakesee.tui", "snakesee.demo")
+
+        with pytest.raises(SystemExit) as exc_info:
+            demo()
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        assert "textual" in captured.err
 
 
 class TestStatus:


### PR DESCRIPTION
## Summary

`snakesee watch` and `snakesee demo` import the Textual TUI stack lazily. When `textual`, `rich-pixels`, or `pillow` are missing, the commands crashed with a raw `ModuleNotFoundError` traceback (e.g. `from textual.app import App`). This happens in partial installs — notably a conda/bioconda package whose recipe omits the TUI dependencies, as reported in #86.

This PR makes the two TUI-launching commands fail gracefully with an actionable install hint on stderr instead of a traceback. The packaging defect itself lives in the bioconda recipe (`pyproject.toml` correctly declares all the deps); this is the snakesee-side robustness improvement so the failure mode is friendly regardless of how the install got into that state.

## Changes

- Add `_is_missing_tui_dependency` / `_exit_missing_tui_dependency` helpers to `cli.py`.
- Wrap the deferred TUI imports in `watch` and `demo` to catch a missing TUI dependency and exit with a clear message + install hint, while re-raising any non-TUI `ModuleNotFoundError` (so genuine internal import bugs are not masked).
- The non-interactive commands (`status`, `profile-export`, `profile-show`, `log-handler-path`) never import the TUI stack and are unaffected.

## Testing

- New `TestMissingTuiDependency` in `tests/test_cli.py` covers the classifier, the exit helper's stderr message + exit code, and end-to-end `watch`/`demo` behavior with `textual` blocked from `sys.modules`.
- `uv run pytest tests/test_cli.py` — 31 passed. `ruff` and `mypy` clean on changed files.

Refs #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI behavior when optional TUI components are not installed: `watch` and `demo` now fail gracefully with clear, actionable install/reinstall guidance instead of raw import errors.

* **Tests**
  * Added coverage to simulate missing TUI dependencies and verify both `watch` and `demo` exit with the correct status code while emitting the expected user-facing message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->