### PR TITLE
fix: unbreak Read the Docs build (uv workspace+editable) and guard it in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,3 +53,42 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: fg-labs/snakesee
+
+  # Reproduce the exact Read the Docs build so a pyproject.toml that the
+  # RTD-pinned uv cannot parse fails CI instead of only failing the RTD build.
+  # The main Tests job uses a newer uv (UV_VERSION above) that tolerates more
+  # syntax, so it cannot catch incompatibilities with the older uv RTD pins.
+  # The uv version is read straight from .readthedocs.yml so this job never
+  # drifts from the real build.
+  ReadTheDocs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Extract uv version pinned by Read the Docs
+        id: rtd
+        run: |
+          set -euo pipefail
+          uv_version="$(sed -nE 's/.*uv==([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' .readthedocs.yml | head -1)"
+          if [ -z "${uv_version}" ]; then
+            echo "Could not find a pinned uv version (uv==X.Y.Z) in .readthedocs.yml" >&2
+            exit 1
+          fi
+          echo "Read the Docs pins uv==${uv_version}"
+          echo "uv_version=${uv_version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Reproduce the Read the Docs install
+        run: |
+          set -euo pipefail
+          python -m venv .rtd-venv
+          .rtd-venv/bin/pip install --upgrade --no-cache-dir pip setuptools
+          .rtd-venv/bin/pip install "uv==${{ steps.rtd.outputs.uv_version }}"
+          VIRTUAL_ENV=.rtd-venv .rtd-venv/bin/uv pip install --group docs .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ members = [
 ]
 
 [tool.uv.sources]
-snakemake-logger-plugin-snakesee = { workspace = true, editable = true }
+snakemake-logger-plugin-snakesee = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
The Read the Docs build is failing during dependency install:

```
error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 80, column 36
   |
80 | snakemake-logger-plugin-snakesee = { workspace = true, editable = true }
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cannot specify both `workspace` and `editable`
```

## Cause

`.readthedocs.yml` pins `uv==0.6.10`, which rejects a `[tool.uv.sources]` entry that sets both `workspace = true` and `editable = true`. Newer uv (the `UV_VERSION` used by the `Tests` job, and current local installs) silently tolerates the combination, which is why CI and local `uv sync` stayed green while only the RTD build broke.

## Fix

uv installs workspace members as editable by default, so `editable = true` is redundant. Dropping it parses cleanly under uv 0.6.10 while preserving the editable install. Verified with the exact RTD uv:

- `uv export` still emits `-e ./snakemake-logger-plugin-snakesee`
- `VIRTUAL_ENV=… uv pip install --group docs .` under a fresh `uv==0.6.10` venv now resolves and installs (exit 0)

## Preventing recurrence

The existing `Tests` job builds the docs, but with a newer uv than RTD pins, so it cannot catch syntax the older RTD uv rejects. This PR adds a `ReadTheDocs` CI job that reproduces the RTD build exactly:

- reads the pinned uv version **straight from `.readthedocs.yml`** (so the job never drifts from the real build when the pin changes)
- runs RTD's exact `uv pip install --group docs .` in a throwaway venv

Any future `pyproject.toml` that the RTD-pinned uv cannot parse now fails CI instead of only surfacing on Read the Docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a CI job that mirrors the Read the Docs build environment more closely for documentation checks.
  * The job now uses the same pinned `uv` version and install flow expected in that environment.

* **Chores**
  * Updated a workspace dependency configuration to use the standard non-editable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->