### PR TITLE
docs: add Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![PyPI version][pypi-badge]][pypi-link]
 [![PyPI downloads][pypi-downloads-badge]][pypi-link]
 [![Bioconda][bioconda-badge]][bioconda-link]
+[![DOI][doi-badge]][doi-link]
 
 **A terminal UI for monitoring Snakemake workflows.**
 
@@ -429,3 +430,5 @@ This codebase was written with the assistance of AI (Claude). All code has been 
 [pypi-downloads-badge]: https://img.shields.io/pypi/dm/snakesee
 [bioconda-badge]: https://img.shields.io/conda/vn/bioconda/snakesee
 [bioconda-link]: https://anaconda.org/bioconda/snakesee
+[doi-badge]: https://zenodo.org/badge/DOI/10.5281/zenodo.21446438.svg
+[doi-link]: https://doi.org/10.5281/zenodo.21446438


### PR DESCRIPTION
snakesee is now archived on Zenodo via the GitHub integration.

This adds a DOI badge using `10.5281/zenodo.21446438`, the concept DOI covering all versions, which always resolves to the latest release.

Verified: currently resolves to `0.9.0`.

Note: the archive covers the five most recent releases (`0.6.2` through `0.9.0`). Earlier releases and the `snakesee-logger` sub-crate tags were intentionally not archived.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Zenodo DOI badge to the project README.
  * Added links supporting the badge display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->